### PR TITLE
fix(make): avoid using subshell after nohup

### DIFF
--- a/make/projppu.mk
+++ b/make/projppu.mk
@@ -42,7 +42,7 @@ ppu_build::
 	$(Q)chmod 0644 $(PROJ_PPU)
 	$(Q)nohup bash -c "md5sum < $(PROJ_PPU) > $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).md5 && chmod 0644 $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).md5" &
 	$(Q)nohup bash -c "sha256sum < $(PROJ_PPU) > $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).sha256 && chmod 0644 $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).sha256" &
-	$(Q)for PKG in $(PROJ_SHIPDIR)/$$(basename $(PROJ_PPU_LONGNAME) .pkg)_*.pkg ; do chmod 0644 $$PKG; nohup bash -c "md5sum < $$PKG > $$PKG.md5 && chmod 0644 $$PKG.md5" &; nohup bash -c "sha256sum < $$PKG > $$PKG.sha256 && chmod 0644 $$PKG.sha256" &; done
+	$(Q)for PKG in $(PROJ_SHIPDIR)/$$(basename $(PROJ_PPU_LONGNAME) .pkg)_*.pkg ; do chmod 0644 $$PKG ; (nohup bash -c "md5sum < $$PKG > $$PKG.md5 && chmod 0644 $$PKG.md5" &) ; (nohup bash -c "sha256sum < $$PKG > $$PKG.sha256 && chmod 0644 $$PKG.sha256" &) ; done
 	$(Q)ln -sf $(PROJ_SHIPDIR)/$$(readlink $(PROJ_RELEASE)).commit $(PROJ_ROOTFS_COMMIT)
 	$(Q)echo $(PROJ_BUILD_COMMIT) > $(PROJ_SHIPDIR)/$$(readlink $(PROJ_RELEASE)).commit
 

--- a/make/projppu.mk
+++ b/make/projppu.mk
@@ -40,9 +40,9 @@ ppu_build::
 	$(Q)ln -sf $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME) $(PROJ_PPU)
 	$(Q)ln -sf $(PROJ_SHIPDIR)/$$(readlink $(PROJ_RELEASE))_rootfs.md5 $(PROJ_ROOTFS_MD5)
 	$(Q)chmod 0644 $(PROJ_PPU)
-	$(Q)nohup (md5sum < $(PROJ_PPU) > $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).md5 && chmod 0644 $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).md5) &
-	$(Q)nohup (sha256sum < $(PROJ_PPU) > $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).sha256 && chmod 0644 $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).sha256) &
-	$(Q)for PKG in $(PROJ_SHIPDIR)/$$(basename $(PROJ_PPU_LONGNAME) .pkg)_*.pkg ; do chmod 0644 $$PKG; nohup (md5sum < $$PKG > $$PKG.md5 && chmod 0644 $$PKG.md5) &; nohup (sha256sum < $$PKG > $$PKG.sha256 && chmod 0644 $$PKG.sha256) &; done
+	$(Q)nohup bash -c "md5sum < $(PROJ_PPU) > $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).md5 && chmod 0644 $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).md5" &
+	$(Q)nohup bash -c "sha256sum < $(PROJ_PPU) > $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).sha256 && chmod 0644 $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).sha256" &
+	$(Q)for PKG in $(PROJ_SHIPDIR)/$$(basename $(PROJ_PPU_LONGNAME) .pkg)_*.pkg ; do chmod 0644 $$PKG; nohup bash -c "md5sum < $$PKG > $$PKG.md5 && chmod 0644 $$PKG.md5" &; nohup bash -c "sha256sum < $$PKG > $$PKG.sha256 && chmod 0644 $$PKG.sha256" &; done
 	$(Q)ln -sf $(PROJ_SHIPDIR)/$$(readlink $(PROJ_RELEASE)).commit $(PROJ_ROOTFS_COMMIT)
 	$(Q)echo $(PROJ_BUILD_COMMIT) > $(PROJ_SHIPDIR)/$$(readlink $(PROJ_RELEASE)).commit
 


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Avoid using subshell after nohup

#### Which issue(s) this PR fixes

- Related to https://github.com/bigstack-oss/triangle/issues/30

#### Special notes for your reviewer

#### Additional documentation
