### PR TITLE
fix(install): exclude fc and iscsi hosts from the install process

### DIFF
--- a/data/hex_install/hex_install.sh.in
+++ b/data/hex_install/hex_install.sh.in
@@ -647,8 +647,10 @@ FormatDataHDD()
 {
     SYSDEV=$(basename $TEMP_HDD)
     for BLOCKDEV in /sys/block/sd* /sys/block/nvme* ; do
-        if readlink $BLOCKDEV | egrep -q -v "loop|usb|$SYSDEV"
-        then
+        # filter out unwanted devices
+        # rport: fc host
+        # session: iscsi host
+        if readlink $BLOCKDEV | egrep -q -v "loop|usb|rport|session|$SYSDEV" ; then
             DEV=/dev/$(basename $BLOCKDEV)
             [ -b $DEV ] || continue
             PrepareDataDisk $DEV

--- a/src/modules/cli_install.cpp
+++ b/src/modules/cli_install.cpp
@@ -28,7 +28,7 @@ RestoreMain(int argc, const char** argv)
         std::string device;
         int index;
 
-        std::string cmd = "/bin/lsblk -dn --sort name -o NAME,SIZE,MODEL,TYPE,TRAN | /bin/grep disk | /bin/egrep -v 'disk usb|disk fc' | /usr/bin/awk ";
+        std::string cmd = "/bin/lsblk -dn --sort name -o NAME,SIZE,MODEL,TYPE,TRAN | /bin/grep disk | /bin/egrep -v 'disk usb|disk fc|disk iscsi' | /usr/bin/awk ";
         std::string optCmd = cmd + "'{print \"/dev/\"$1}'";
         std::string descCmd = cmd + "'{ printf \"%-8s %-8s %s\\n\", $1, $2, $3 }'";
 


### PR DESCRIPTION
#### What type of PR is this?

/kind fix

#### What this PR does / why we need it

- Exclude FC and iSCSI hosts from the installation process

#### Which issue(s) this PR fixes

- Fix https://github.com/bigstack-oss/cubecos/issues/405

#### Special notes for your reviewer

- Currently, we are formatting other disks to XFS after flashing the system partition with CubeCOS firmware during the installation process. As pointed out by @bigstack-brian-su , it might be safer to be happened during CLI > cluster > set_ready and show the list of intended formatting disks in the console before formatting them.

#### Additional documentation
