### PR TITLE
fix(hex_config): resolve logrotate config conflict with rsyslog default configs

### DIFF
--- a/rootfs/Makefile
+++ b/rootfs/Makefile
@@ -158,6 +158,7 @@ full_rootfs_install::
 	$(Q)ln -sf /lib/systemd/system/systemd-hexctl-user.service $(ROOTDIR)/etc/systemd/system/multi-user.target.wants/systemd-hexctl-user.service
 	$(Q)chroot $(ROOTDIR) systemctl disable crond sshd
 	$(Q)chroot $(ROOTDIR) mv /etc/cron.daily/logrotate /etc/cron.hourly/ || true
+	$(Q)chroot $(ROOTDIR) mv /etc/logrotate.d/rsyslog /etc/logrotate.d/rsyslog.disabled
 	$(Q)chroot $(ROOTDIR) bash -c "rm -rf /usr/local/share/* /usr/share/{man,doc,licenses} /usr/src /usr/local/src /var/{log,cache}/* /tmp/* /lib/.build-id"
 
 $(call HEX_CHECKROOTFS,$(HEX_FULL_ROOTFS))

--- a/src/modules/config_syslogd.cpp
+++ b/src/modules/config_syslogd.cpp
@@ -1,15 +1,14 @@
 // HEX SDK
 
-#include <string>
-#include <signal.h>
-#include <vector>
-#include <sys/statvfs.h>
 #include <errno.h>
-#include <unistd.h>
+#include <signal.h>
+#include <string>
+#include <sys/statvfs.h>
+#include <vector>
 
 #include <hex/log.h>
-#include <hex/process.h>
 #include <hex/logrotate.h>
+#include <hex/process.h>
 #include <hex/process_util.h>
 #include <hex/tuning.h>
 
@@ -23,7 +22,13 @@ static const char RSYSLOG_CONF[] = "/etc/rsyslog.conf";
 static const char LOGDIR[] = "/var/log";
 
 // rotate daily and enable copytruncate
-static LogRotateConf log_conf("syslog", "/var/log/messages /var/log/secure /var/log/cron", DAILY, 128, 0, true);
+static LogRotateConf log_conf(
+    "syslog",
+    "/var/log/messages /var/log/secure /var/log/cron /var/log/maillog /var/log/spooler",
+    DAILY,
+    128,
+    0,
+    true);
 
 static bool s_bLogrotateChanged = false;
 
@@ -65,17 +70,17 @@ UpdateConfig(const char* filepath)
 static uint64_t
 GetDiskSizeKB(const char* absoluteFilePath)
 {
-   struct statvfs fs;
-   uint64_t diskSize = 5242880; // 5GB = 5 * 1024 * 1024 KB (minimum)
+    struct statvfs fs;
+    uint64_t diskSize = 5242880; // 5GB = 5 * 1024 * 1024 KB (minimum)
 
-   if (statvfs(absoluteFilePath, &fs) == -1) {
-       HexLogDebug("Failed to get disk size (errno=%d) using default", errno);
-       return diskSize;
-   }
+    if (statvfs(absoluteFilePath, &fs) == -1) {
+        HexLogDebug("Failed to get disk size (errno=%d) using default", errno);
+        return diskSize;
+    }
 
-   diskSize = fs.f_bsize * fs.f_blocks / 1024;
-   HexLogDebug("Disk size: %ld (KB) (%ld,%ld)", diskSize, fs.f_bsize, fs.f_blocks);
-   return diskSize;
+    diskSize = fs.f_bsize * fs.f_blocks / 1024;
+    HexLogDebug("Disk size: %ld (KB) (%ld,%ld)", diskSize, fs.f_bsize, fs.f_blocks);
+    return diskSize;
 }
 
 static bool
@@ -83,27 +88,27 @@ UpdateLogrotateConfig(unsigned percent)
 {
     // We should not have any problem of underflow becuase of the minimum disk size,
     // but we need to prevent integer overflow. So we do division first
+    std::uint64_t upperlimit = GetDiskSizeKB(LOGDIR) / 100 * percent;
 
-    char buf[64];
-    uint64_t upperlimit = GetDiskSizeKB(LOGDIR) / 100 * percent;
-
-    snprintf(buf, 64, "/usr/sbin/hex_trim_syslog %lu", upperlimit);
-    log_conf.postRotateCmds = buf;
+    std::stringstream cmd;
+    cmd << "/usr/sbin/hex_trim_syslog "
+        << upperlimit
+        << " || true; /usr/bin/systemctl -s HUP kill rsyslog.service >/dev/null 2>&1 || true";
+    log_conf.postRotateCmds = cmd.str();
     WriteLogRotateConf(log_conf);
 
     return true;
 }
 
 static bool
-Parse(const char *name, const char *value, bool isNew)
+Parse(const char* name, const char* value, bool isNew)
 {
     bool r = true;
 
     TuneStatus s = ParseTune(name, value, isNew);
     if (s == TUNE_INVALID_NAME) {
         HexLogWarning("Unknown settings name \"%s\" = \"%s\" ignored", name, value);
-    }
-    else if (s == TUNE_INVALID_VALUE) {
+    } else if (s == TUNE_INVALID_VALUE) {
         HexLogError("Invalid settings value \"%s\" = \"%s\"", name, value);
         r = false;
     }
@@ -147,4 +152,3 @@ CONFIG_MODULE(syslog, 0, Parse, NULL, Prepare, Commit);
 CONFIG_FIRST(syslog);
 
 CONFIG_SUPPORT_FILE("/etc/rsyslogd.conf");
-

--- a/src/modules/config_syslogd.cpp
+++ b/src/modules/config_syslogd.cpp
@@ -18,19 +18,7 @@
 
 static const char RSYSLOG[] = "rsyslog";
 static const char RSYSLOG_CONF[] = "/etc/rsyslog.conf";
-
-static const char LOGDIR[] = "/var/log";
-
-// rotate daily and enable copytruncate
-static LogRotateConf log_conf(
-    "syslog",
-    "/var/log/messages /var/log/secure /var/log/cron /var/log/maillog /var/log/spooler",
-    DAILY,
-    128,
-    0,
-    true);
-
-static bool s_bLogrotateChanged = false;
+static const char HEX_RSYSLOG_CONF[] = "/etc/rsyslog.d/hex.conf";
 
 // private tunings
 CONFIG_TUNING_UINT(SYSLOG_DISK_PERC, "syslog.disk_percentage", TUNING_UNPUB, "Set max (all) log file size to a percentage of the partition space.", 5, 1, 50);
@@ -66,6 +54,41 @@ UpdateConfig(const char* filepath)
     return true;
 }
 
+static bool
+updateHexLogConfig()
+{
+    FILE* fout = fopen(HEX_RSYSLOG_CONF, "w");
+    if (!fout) {
+        return false;
+    }
+
+    fprintf(fout, ":programname, isequal, \"hex_cli\"  /var/log/hex_cli.log\n");
+    fprintf(fout, ":programname, isequal, \"hex_config\"  /var/log/hex_config.log\n");
+    fprintf(fout, ":programname, isequal, \"hex_firsttime\"  /var/log/hex_firsttime.log\n");
+    fprintf(fout, ":programname, isequal, \"hex_sdk\"  /var/log/hex_sdk.log\n");
+    fprintf(fout, ":programname, isequal, \"hex_translate\"  /var/log/hex_translate.log\n");
+
+    fclose(fout);
+    return true;
+}
+
+static const char LOGDIR[] = "/var/log";
+
+// rotate daily and enable copytruncate
+static LogRotateConf logConf(
+    "syslog",
+    "/var/log/messages\n"
+    "/var/log/secure\n"
+    "/var/log/cron\n"
+    "/var/log/maillog\n"
+    "/var/log/spooler",
+    DAILY,
+    128,
+    0,
+    true);
+
+static bool s_bLogrotateChanged = false;
+
 // Determine the total disk size in KB
 static uint64_t
 GetDiskSizeKB(const char* absoluteFilePath)
@@ -94,10 +117,28 @@ UpdateLogrotateConfig(unsigned percent)
     cmd << "/usr/sbin/hex_trim_syslog "
         << upperlimit
         << " || true; /usr/bin/systemctl -s HUP kill rsyslog.service >/dev/null 2>&1 || true";
-    log_conf.postRotateCmds = cmd.str();
-    WriteLogRotateConf(log_conf);
+    logConf.postRotateCmds = cmd.str();
+    WriteLogRotateConf(logConf);
 
     return true;
+}
+
+static LogRotateConf hexLogrotateConf(
+    "hex",
+    "/var/log/hex_cli.log\n"
+    "/var/log/hex_config.log\n"
+    "/var/log/hex_firsttime.log\n"
+    "/var/log/hex_sdk.log\n"
+    "/var/log/hex_translate.log",
+    DAILY,
+    128,
+    0,
+    true);
+
+static bool
+writeHexLogrotateConfig()
+{
+    return WriteLogRotateConf(hexLogrotateConf);
 }
 
 static bool
@@ -136,9 +177,11 @@ Commit(bool modified, int dryLevel)
     HEX_DRYRUN_BARRIER(dryLevel, true);
 
     UpdateConfig(RSYSLOG_CONF);
+    updateHexLogConfig();
 
     if (s_bLogrotateChanged) {
         UpdateLogrotateConfig((unsigned)s_diskPercentage);
+        writeHexLogrotateConfig();
         HexUtilSystemF(FWD, 0, "systemctl restart %s", RSYSLOG);
     }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind fix

#### What this PR does / why we need it

- Resolve logrotate config conflicts with rsyslog default configs
- Send hex logs to separated files
  - `/var/log/hex_cli.log`
  - `/var/log/hex_config.log`
  - `/var/log/hex_firsttime.log`
  - `/var/log/hex_sdk.log`
  - `/var/log/hex_translate.log`

#### Which issue(s) this PR fixes

- Fix https://github.com/bigstack-oss/cubecos/issues/90

#### Special notes for your reviewer

#### Additional documentation
