### PR TITLE
fix(hex_cli): include the missing header file

### DIFF
--- a/include/hex/cli_support_helper.h
+++ b/include/hex/cli_support_helper.h
@@ -4,6 +4,7 @@
 #define CLI_SUPPORT_HELPER_H
 
 #include <hex/cli_util.h>
+#include <hex/process.h>
 
 #define SUPPORT_DIR "/var/support/"
 #define HEX_CFG "/usr/sbin/hex_config"


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Include the missing header file in `cli_support_helper.h`

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation
