### PR TITLE
fix(hex_install): exclude zero size devices

### DIFF
--- a/data/hex_install/hex_install.sh.in
+++ b/data/hex_install/hex_install.sh.in
@@ -680,7 +680,7 @@ FormatDataHDD()
             continue
         fi
 
-        # exclude not-writable devices
+        # exclude not writable devices
         if [[ "$(/bin/lsblk -dn -o RO "/dev/${device_basename}")" =~ "1" ]] ; then
             continue
         fi

--- a/data/hex_install/hex_install.sh.in
+++ b/data/hex_install/hex_install.sh.in
@@ -645,18 +645,62 @@ FormatSysHDD()
 
 FormatDataHDD()
 {
-    SYSDEV=$(basename $TEMP_HDD)
-    for BLOCKDEV in /sys/block/sd* /sys/block/nvme* ; do
-        # filter out unwanted devices
-        # rport: fc host
-        # session: iscsi host
-        if readlink $BLOCKDEV | egrep -q -v "loop|usb|rport|session|$SYSDEV" ; then
-            DEV=/dev/$(basename $BLOCKDEV)
-            [ -b $DEV ] || continue
-            PrepareDataDisk $DEV
+    local sys_dev=$(/usr/bin/basename "$TEMP_HDD")
+
+    local block_dev
+    for block_dev in /sys/block/sd* /sys/block/nvme* ; do
+        # skip non-existing links
+        if [[ "$block_dev" == "/sys/block/sd*" ]] ; then
+            continue
         fi
+        if [[ "$block_dev" == "/sys/block/nvme*" ]] ; then
+            continue
+        fi
+
+        local device_basename="$(/usr/bin/basename "$block_dev")"
+
+        # exclude the system disk
+        if [[ "$device_basename" == "$sys_dev" ]] ; then
+            continue
+        fi
+
+        # exclude non-block devices
+        if [[ "$(/bin/lsblk -dn -o TYPE "/dev/${device_basename}")" != "disk" ]] ; then
+            continue
+        fi
+
+        # exclude unsupported devices
+        if [[ "$(/bin/lsblk -dn -o TRAN "/dev/${device_basename}")" == "usb" ]] ; then
+            continue
+        fi
+        if [[ "$(/bin/lsblk -dn -o TRAN "/dev/${device_basename}")" == "fc" ]] ; then
+            continue
+        fi
+        if [[ "$(/bin/lsblk -dn -o TRAN "/dev/${device_basename}")" == "iscsi" ]] ; then
+            continue
+        fi
+
+        # exclude not-writable devices
+        if [[ "$(/bin/lsblk -dn -o RO "/dev/${device_basename}")" =~ "1" ]] ; then
+            continue
+        fi
+
+        # exclude zero size devices
+        if [[ "$(/bin/lsblk -dn -o SIZE "/dev/${device_basename}")" == " 0B" ]] ; then
+            continue
+        fi
+
+        # ensure the device is a block device
+        local device="/dev/${device_basename}"
+        if [ ! -b "$device" ] ; then
+            continue
+        fi
+
+        PrepareDataDisk "$device"
     done
-    sync
+
+    # flush
+    /usr/bin/sync
 }
 
 # main()

--- a/src/hex_sdk_library/exec.cpp
+++ b/src/hex_sdk_library/exec.cpp
@@ -305,17 +305,27 @@ ExecSync(const int& timeoutSeconds, Cmd& command)
 
         // read from stdout
         if (command.captureStdout) {
-            ssize_t bytesRead = ReadByNonblockingPoll(p.stdoutPipeReadEnd, buffer, sizeof(buffer));
-            if (bytesRead > 0) {
-                stdoutStream.write(buffer, bytesRead);
+            // drain the pipe
+            while (true) {
+                ssize_t bytesRead = ReadByNonblockingPoll(p.stdoutPipeReadEnd, buffer, sizeof(buffer));
+                if (bytesRead > 0) {
+                    stdoutStream.write(buffer, bytesRead);
+                } else {
+                    break;
+                }
             }
         }
 
         // read from stderr
         if (command.captureStderr) {
-            ssize_t bytesRead = ReadByNonblockingPoll(p.stderrPipeReadEnd, buffer, sizeof(buffer));
-            if (bytesRead > 0) {
-                stderrStream.write(buffer, bytesRead);
+            // drain the pipe
+            while (true) {
+                ssize_t bytesRead = ReadByNonblockingPoll(p.stderrPipeReadEnd, buffer, sizeof(buffer));
+                if (bytesRead > 0) {
+                    stderrStream.write(buffer, bytesRead);
+                } else {
+                    break;
+                }
             }
         }
 
@@ -331,9 +341,14 @@ ExecSync(const int& timeoutSeconds, Cmd& command)
 
     // read any remaining data
     if (command.captureStdout) {
-        ssize_t bytesRead = ReadByNonblockingPoll(p.stdoutPipeReadEnd, buffer, sizeof(buffer));
-        if (bytesRead > 0) {
-            stdoutStream.write(buffer, bytesRead);
+        // drain the pipe
+        while (true) {
+            ssize_t bytesRead = ReadByNonblockingPoll(p.stdoutPipeReadEnd, buffer, sizeof(buffer));
+            if (bytesRead > 0) {
+                stdoutStream.write(buffer, bytesRead);
+            } else {
+                break;
+            }
         }
 
         // close the read-end
@@ -342,9 +357,14 @@ ExecSync(const int& timeoutSeconds, Cmd& command)
         result.stdoutOutput = stdoutStream.str();
     }
     if (command.captureStderr) {
-        ssize_t bytesRead = ReadByNonblockingPoll(p.stderrPipeReadEnd, buffer, sizeof(buffer));
-        if (bytesRead > 0) {
-            stderrStream.write(buffer, bytesRead);
+        // drain the pipe
+        while (true) {
+            ssize_t bytesRead = ReadByNonblockingPoll(p.stderrPipeReadEnd, buffer, sizeof(buffer));
+            if (bytesRead > 0) {
+                stderrStream.write(buffer, bytesRead);
+            } else {
+                break;
+            }
         }
 
         // close the read-ends

--- a/src/modules/cli_install.cpp
+++ b/src/modules/cli_install.cpp
@@ -1,10 +1,9 @@
 // HEX SDK
 
-#include <hex/process.h>
-#include <hex/log.h>
-
 #include <hex/cli_module.h>
 #include <hex/cli_util.h>
+#include <hex/log.h>
+#include <hex/process.h>
 
 static int
 RestoreMain(int argc, const char** argv)
@@ -12,47 +11,73 @@ RestoreMain(int argc, const char** argv)
     if (argc != 1) {
         return CLI_INVALID_ARGS;
     }
-    else {
-        CliList list;
 
-        if (CliPopulateList(list, "/usr/sbin/hex_install list") != 0)
-            return CLI_UNEXPECTED_ERROR;
-
-        if (list.size() != 1) {
-            HexLogError("restore: expected 1 image, found %zd", list.size());
-            return CLI_UNEXPECTED_ERROR;
-        }
-
-        CliList devices;
-        CliList descriptions;
-        std::string device;
-        int index;
-
-        std::string cmd = "/bin/lsblk -dn --sort name -o NAME,SIZE,MODEL,TYPE,TRAN | /bin/grep disk | /bin/egrep -v 'disk usb|disk fc|disk iscsi' | /usr/bin/awk ";
-        std::string optCmd = cmd + "'{print \"/dev/\"$1}'";
-        std::string descCmd = cmd + "'{ printf \"%-8s %-8s %s\\n\", $1, $2, $3 }'";
-
-        if(CliMatchCmdDescHelper(argc, argv, 1, optCmd, descCmd, &index, &device) != CLI_SUCCESS) {
-            CliPrintf("device name is missing or not found");
-            return CLI_INVALID_ARGS;
-        }
-
-        HexSystemF(0, "echo \"sys.install.hdd=%s\" > /etc/extra_settings.sys", device.c_str());
-
-	CliPrintf("Restoring %s on %s", list[0].c_str(), device.c_str());
-
-        if (!CliReadConfirmation())
-            return CLI_SUCCESS;
-
-        CliPrintf("Starting restore...");
-
-        if (HexSpawn(0, "/usr/sbin/hex_install", "-v", "-w", "-t", "/etc/extra_settings.sys", "restore", list[0].c_str(), NULL) != 0)
-            return CLI_UNEXPECTED_ERROR;
+    CliList list;
+    if (CliPopulateList(list, "/usr/sbin/hex_install list") != 0) {
+        return CLI_UNEXPECTED_ERROR;
     }
+
+    if (list.size() != 1) {
+        HexLogError("restore: expected 1 image, found %zd", list.size());
+        return CLI_UNEXPECTED_ERROR;
+    }
+
+    CliList devices;
+    CliList descriptions;
+    std::string device;
+    int index;
+
+    std::string cmd = "/bin/lsblk -dn --sort name -o NAME,SIZE,MODEL,TYPE,TRAN | /bin/grep disk | /bin/egrep -v 'disk usb|disk fc|disk iscsi' | /usr/bin/awk ";
+    std::string optCmd = cmd + "'{print \"/dev/\"$1}'";
+    std::string descCmd = cmd + "'{ printf \"%-8s %-8s %s\\n\", $1, $2, $3 }'";
+
+    if (CliMatchCmdDescHelper(
+            argc,
+            argv,
+            1,
+            optCmd,
+            descCmd,
+            &index,
+            &device)
+        != CLI_SUCCESS) {
+        CliPrintf("device name is missing or not found");
+        return CLI_INVALID_ARGS;
+    }
+
+    HexSystemF(
+        0,
+        "echo \"sys.install.hdd=%s\" > /etc/extra_settings.sys",
+        device.c_str());
+
+    CliPrintf("Restoring %s on %s", list[0].c_str(), device.c_str());
+
+    if (!CliReadConfirmation()) {
+        return CLI_SUCCESS;
+    }
+
+    CliPrintf("Starting restore...");
+
+    if (HexSpawn(
+            0,
+            "/usr/sbin/hex_install",
+            "-v",
+            "-w",
+            "-t",
+            "/etc/extra_settings.sys",
+            "restore",
+            list[0].c_str(),
+            NULL)
+        != 0) {
+        return CLI_UNEXPECTED_ERROR;
+    }
+
     return CLI_SUCCESS;
 }
 
-CLI_MODE_COMMAND(CLI_TOP_MODE, "restore", RestoreMain, 0,
+CLI_MODE_COMMAND(
+    CLI_TOP_MODE,
+    "restore",
+    RestoreMain,
+    0,
     "Restore a firmware image.",
     "restore [<device>]");
-


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- Format cli_install.cpp
- Refactor FormatDataHDD in hex_install.sh
- Exclude non-writable and zero size devices in hex_install.sh

#### Which issue(s) this PR fixes

- Fix https://github.com/bigstack-oss/cubecos/issues/505

#### Special notes for your reviewer

#### Additional documentation
