### PR TITLE
chore: outdated package version updates

### DIFF
--- a/rootfs/pkgs_hex2.0_x86_64.mk
+++ b/rootfs/pkgs_hex2.0_x86_64.mk
@@ -34,7 +34,7 @@ BASE_PKGS += kmod kexec-tools hostname cpio less tree ncurses openssl-devel glib
 
 CENTOS_MIRROR := https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages
 DISTRO := el9
-GRUB2_VER := 2.06-116
+GRUB2_VER := 2.06-118
 
 BASE_LOCK_PKGS += $(CENTOS_MIRROR)/grub2-common-$(GRUB2_VER).$(DISTRO).noarch.rpm
 BASE_LOCK_PKGS += $(CENTOS_MIRROR)/grub2-pc-$(GRUB2_VER).$(DISTRO).x86_64.rpm


### PR DESCRIPTION
#### What type of PR is this?

Chore

#### What this PR does / why we need it

Update outdated package versions.

#### Which issue(s) this PR fixes

None

#### Special notes for your reviewer

> Note

#### Additional documentation

- GRUB2 `2.06-116` no longer exists. The closest version is `2.06-118`.
   <img width="778" height="249" alt="{7AECC904-2D90-4CF4-959C-673B3527A6C6}" src="https://github.com/user-attachments/assets/c7802933-8640-4be5-babd-214b91cb09ff" />
   <img width="1181" height="568" alt="{BD2017EF-80C1-42B9-B850-39F688165518}" src="https://github.com/user-attachments/assets/de0bb74c-f19f-46c3-a14e-8bca0405c59a" />
   <img width="1061" height="492" alt="{EBB97C4A-3F4A-4B09-811C-84DE2B3E90F5}" src="https://github.com/user-attachments/assets/0bfb43bd-b9c5-4807-96ab-173bae561d11" />

