### PR TITLE
build(make): silence nohup output in projppu checksums

### DIFF
--- a/make/projppu.mk
+++ b/make/projppu.mk
@@ -40,10 +40,10 @@ ppu_build::
 	$(Q)ln -sf $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME) $(PROJ_PPU)
 	$(Q)ln -sf $(PROJ_SHIPDIR)/$$(readlink $(PROJ_RELEASE))_rootfs.md5 $(PROJ_ROOTFS_MD5)
 	$(Q)chmod 0644 $(PROJ_PPU)
-	$(Q)nohup bash -c "md5sum < $(PROJ_PPU) > $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).md5 && chmod 0644 $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).md5" 2>&1 &
-	$(Q)nohup bash -c "sha256sum < $(PROJ_PPU) > $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).sha256 && chmod 0644 $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).sha256" 2>&1 &
+	$(Q)nohup bash -c "md5sum < $(PROJ_PPU) > $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).md5 && chmod 0644 $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).md5" $(QEND) &
+	$(Q)nohup bash -c "sha256sum < $(PROJ_PPU) > $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).sha256 && chmod 0644 $(PROJ_SHIPDIR)/$(PROJ_PPU_LONGNAME).sha256" $(QEND) &
 	$(Q)for PKG in $(PROJ_SHIPDIR)/$$(basename $(PROJ_PPU_LONGNAME) .pkg)_*.pkg ; do chmod 0644 $$PKG ; done
-	$(Q)nohup bash -c "for PKG in $(PROJ_SHIPDIR)/$$(basename $(PROJ_PPU_LONGNAME) .pkg)_*.pkg ; do md5sum < $$PKG > $$PKG.md5 && chmod 0644 $$PKG.md5 ; sha256sum < $$PKG > $$PKG.sha256 && chmod 0644 $$PKG.sha256 ; done" >/dev/null 2>&1 &
+	$(Q)nohup bash -c "for PKG in $(PROJ_SHIPDIR)/$$(basename $(PROJ_PPU_LONGNAME) .pkg)_*.pkg ; do md5sum < $$PKG > $$PKG.md5 && chmod 0644 $$PKG.md5 ; sha256sum < $$PKG > $$PKG.sha256 && chmod 0644 $$PKG.sha256 ; done" $(QEND) &
 	$(Q)ln -sf $(PROJ_SHIPDIR)/$$(readlink $(PROJ_RELEASE)).commit $(PROJ_ROOTFS_COMMIT)
 	$(Q)echo $(PROJ_BUILD_COMMIT) > $(PROJ_SHIPDIR)/$$(readlink $(PROJ_RELEASE)).commit
 


### PR DESCRIPTION
#### What this PR does

The async checksum lines in `make/projppu.mk` used
`nohup bash -c "…>file…" 2>&1 &` — so nohup's *own* stdout was a tty and it printed
`nohup: ignoring input … appending output to 'nohup.out'` into the build log.

Redirect nohup's output with the `$(QEND)` macro (`>/dev/null 2>&1` in normal builds,
empty under `VERBOSE`), matching the cgroups-v1 cleanup. The
`nohup md5sum < IN > OUT 2>&1` lines are left as-is — they already send nohup's stdout
to the checksum file, and `$(QEND)` would clobber it.

#### Validation

Part of the cubecos build-output cleanup validated via remake jail + `make pxe` twice
(bigstack-oss/cubecos#1007): the `nohup:` message no longer appears in the build log.

#### Linked issue

Refs bigstack-oss/cubecos#1005 (cross-repo; the build-incrementality + output-cleanup tracking bug).
