### PR TITLE
fix(exec): detach child stdin to /dev/null so commits don't hang on a serial console

### DIFF
--- a/src/hex_sdk_library/Makefile
+++ b/src/hex_sdk_library/Makefile
@@ -26,6 +26,9 @@ SUBDIRS += dryrun
 SUBDIRS += crypto
 SUBDIRS += license
 
+# Unit tests for sources built directly into the SDK library (e.g. exec.cpp).
+SUBDIRS += tests
+
 LIB = $(HEX_SDK_LIB_ARCHIVE)
 
 LIB_SRCS = exec.cpp

--- a/src/hex_sdk_library/exec.cpp
+++ b/src/hex_sdk_library/exec.cpp
@@ -126,13 +126,9 @@ Exec(const Cmd& command, bool daemonize)
 
     // child process
     if (pid == 0) {
-        // Detach stdin from any inherited controlling terminal. When a commit runs
-        // on a serial console (e.g. IPMI Serial-over-LAN, /dev/ttyS0), the child
-        // would otherwise inherit that UART as stdin; tools that initialize a
-        // terminal on stdin (such as mongosh) then block forever opening it in
-        // tty_port_block_til_ready (waiting for carrier, CLOCAL not set). Commit
-        // subprocesses never read stdin, so point it at /dev/null. Mirrors the
-        // stdout/stderr /dev/null handling below.
+        // Redirect stdin to /dev/null so the child doesn't inherit a serial console
+        // (e.g. IPMI SoL /dev/ttyS0) as stdin; tools like mongosh would otherwise
+        // block opening the controlling TTY. Mirrors the stdout/stderr handling below.
         int devNullIn = open("/dev/null", O_RDONLY);
         if (devNullIn == -1 || dup2(devNullIn, STDIN_FILENO) == -1) {
             _exit(EXIT_FAILURE);

--- a/src/hex_sdk_library/exec.cpp
+++ b/src/hex_sdk_library/exec.cpp
@@ -126,6 +126,21 @@ Exec(const Cmd& command, bool daemonize)
 
     // child process
     if (pid == 0) {
+        // Detach stdin from any inherited controlling terminal. When a commit runs
+        // on a serial console (e.g. IPMI Serial-over-LAN, /dev/ttyS0), the child
+        // would otherwise inherit that UART as stdin; tools that initialize a
+        // terminal on stdin (such as mongosh) then block forever opening it in
+        // tty_port_block_til_ready (waiting for carrier, CLOCAL not set). Commit
+        // subprocesses never read stdin, so point it at /dev/null. Mirrors the
+        // stdout/stderr /dev/null handling below.
+        int devNullIn = open("/dev/null", O_RDONLY);
+        if (devNullIn == -1 || dup2(devNullIn, STDIN_FILENO) == -1) {
+            _exit(EXIT_FAILURE);
+        }
+        if (devNullIn > STDIN_FILENO) {
+            close(devNullIn);
+        }
+
         if (command.captureStdout) {
             // close the read-ends of the pipe, child only needs to write
             if (close(stdoutPipe[0]) == -1) {

--- a/src/hex_sdk_library/tests/Makefile
+++ b/src/hex_sdk_library/tests/Makefile
@@ -1,0 +1,7 @@
+# HEX SDK
+
+include ../../../../build.mk
+
+TESTS_LIBS = $(HEX_SDK_LIB_ARCHIVE)
+
+include $(HEX_MAKEDIR)/hex_sdk.mk

--- a/src/hex_sdk_library/tests/test_exec_stdin_01.cpp
+++ b/src/hex_sdk_library/tests/test_exec_stdin_01.cpp
@@ -1,0 +1,42 @@
+// HEX SDK
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <string>
+
+#include <hex/exec.hpp>
+#include <hex/test.h>
+
+// Verify Exec() detaches the child's stdin to /dev/null instead of letting it
+// inherit the parent's stdin. This guards the serial-console hang fix: we give
+// the test process (the parent) a recognizable, non-/dev/null stdin and confirm
+// the child still sees /dev/null. Without the fix the child would inherit the
+// parent's fd and the assertion below would fail.
+int main()
+{
+    // Point the parent's stdin at something that is clearly not /dev/null.
+    int fd = open("/dev/zero", O_RDONLY);
+    HEX_TEST_FATAL(fd != -1);
+    HEX_TEST_FATAL(dup2(fd, STDIN_FILENO) != -1);
+    if (fd > STDIN_FILENO) {
+        close(fd);
+    }
+
+    // The child reports what its own stdin (fd 0) points to.
+    const ExecSyncResult result =
+        ExecBashSync(10, true /*captureStdout*/, false /*captureStderr*/, {}, "readlink /proc/self/fd/0");
+
+    HEX_TEST(result.exitCode == 0);
+    HEX_TEST(!result.isTimedOut);
+
+    // Strip the trailing newline from readlink's output.
+    std::string target = result.stdoutOutput;
+    while (!target.empty() && (target.back() == '\n' || target.back() == '\r')) {
+        target.pop_back();
+    }
+
+    HEX_TEST(target == "/dev/null");
+
+    return HexTestResult;
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

On a serial-console install (IPMI Serial-over-LAN, `/dev/ttyS0`), `hex_config`'s commit subprocesses inherit the UART as stdin. `Exec()` redirected the child's stdout/stderr but left **stdin** inherited from the parent. Tools that initialize a terminal on stdin — e.g. `mongosh` during the **mongodb** module commit — then block forever opening the controlling TTY in `tty_port_block_til_ready` (waiting for carrier; `CLOCAL` unset), stalling the entire policy apply at the mongodb stage. VGA/console installs are unaffected because their stdin is not a blocking UART.

Commit subprocesses never read stdin, so this redirects the child's stdin to `/dev/null` in `Exec()`, mirroring the existing stdout/stderr `/dev/null` handling. Commits become independent of console type (serial/SoL vs VGA).

#### Which issue(s) this PR fixes

Fixes bigstack-oss/cubecos#1016 (the cubecos tracking issue; cubecos picks up this fix via a hex submodule bump).

#### Special notes for your reviewer

> Note

Adds `test_exec_stdin_01`: gives the parent process a non-`/dev/null` stdin (`/dev/zero`) and asserts that an `Exec()`-spawned child still sees `/dev/null`. Confirmed it **fails without** the fix (child inherits `/dev/zero`) and **passes with** it. Full `hex_sdk_library` `make test` is green (128/128) in the centos9 jail.

Also verified end-to-end downstream: a full serial-console (SoL) CubeCOS install on a build carrying this fix completes all 22 bootstrap stages — the mongodb stage no longer hangs.

#### Additional documentation

```docs
Known-issue note drafted in bigstack-handbook: kb/cubecos/known-issues/mongodb-commit-hang-serial-console.md
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
