### PR TITLE
chore(grub): bump grub2 build number from 118 to 129

### DIFF
--- a/rootfs/pkgs_hex2.0_x86_64.mk
+++ b/rootfs/pkgs_hex2.0_x86_64.mk
@@ -34,7 +34,7 @@ BASE_PKGS += kmod kexec-tools hostname cpio less tree ncurses openssl-devel glib
 
 CENTOS_MIRROR := https://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages
 DISTRO := el9
-GRUB2_VER := 2.06-118
+GRUB2_VER := 2.06-129
 
 BASE_LOCK_PKGS += $(CENTOS_MIRROR)/grub2-common-$(GRUB2_VER).$(DISTRO).noarch.rpm
 BASE_LOCK_PKGS += $(CENTOS_MIRROR)/grub2-pc-$(GRUB2_VER).$(DISTRO).x86_64.rpm


### PR DESCRIPTION
#### What type of PR is this?

- chore

#### What this PR does / why we need it

- Bump grub2 build number from 118 to 129

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation
