### PR TITLE
fix: quiet steady-state log noise from DumpInterface and license probes

### DIFF
--- a/scripts/functions
+++ b/scripts/functions
@@ -1311,6 +1311,7 @@ DumpInterface()
     I=0
     FAILED=0
     declare -A ORIG_STATE=()
+    declare -A PROBED=()
     while true ; do
         eval HWADDR=\${T_sys_net_if_mac_eth${I}}
         if [ -z "$HWADDR" ] ; then
@@ -1326,13 +1327,17 @@ DumpInterface()
             if cat /sys/class/net/eth$I/carrier >/dev/null 2>&1 ; then
                 ORIG_STATE[$I]="UP"
             else
-                /usr/sbin/ip link set eth$I up >/dev/null 2>&1
                 ORIG_STATE[$I]="DOWN"
-                for S in $(seq $wait_sec) ; do
-                    SPEED=$(cat /sys/class/net/eth$I/speed 2>/dev/null)
-                    [ "x$SPEED" = "x" ] || break
-                    sleep 1
-                done
+                # only up-probe down NICs interactively; json pollers must not bounce links
+                if [ "x$FORMAT" != "xjson" ] ; then
+                    /usr/sbin/ip link set eth$I up >/dev/null 2>&1
+                    PROBED[$I]=1
+                    for S in $(seq $wait_sec) ; do
+                        SPEED=$(cat /sys/class/net/eth$I/speed 2>/dev/null)
+                        [ "x$SPEED" = "x" ] || break
+                        sleep 1
+                    done
+                fi
             fi
         fi
         I=$(expr $I + 1)
@@ -1375,7 +1380,7 @@ DumpInterface()
                 SPEED=""
             fi
             STATE=${ORIG_STATE[$I]}
-            if [ "$STATE" == "DOWN" ] ; then
+            if [ -n "${PROBED[$I]}" ] ; then
                 /usr/sbin/ip link set eth$I down >/dev/null 2>&1
             fi
         else

--- a/src/hex_config/config_main.cpp
+++ b/src/hex_config/config_main.cpp
@@ -1745,7 +1745,7 @@ LicenseCheck(const std::string& app, const std::string& filename)
 
     int result = HexLicenseCheck(app, &type, &serial, filename);
     if (result > 0) {
-        HexLogNotice("License (type: %s) is still valid for %d days", type.c_str(), result);
+        HexLogDebug("License (type: %s) is still valid for %d days", type.c_str(), result);
     }
     else if (result == LICENSE_BADSYS) {
         HexLogNotice("License system is compromised");
@@ -1757,7 +1757,7 @@ LicenseCheck(const std::string& app, const std::string& filename)
         HexLogNotice("Invalid license files for this hardware (serial: %s)", serial.c_str());
     }
     else if (result == LICENSE_NOEXIST) {
-        HexLogNotice("License files are not installed");
+        HexLogDebug("License files are not installed");
     }
     else if (result == LICENSE_EXPIRED) {
         HexLogNotice("License files has been expired");
@@ -2145,7 +2145,7 @@ main(int argc, char **argv)
     else if (s_lmiRestartNeeded)
         status |= CONFIG_EXIT_NEED_LMI_RESTART;
 
-    HexLogInfo("Command %s exited with status: %d", fullCmd.c_str(), status);
+    HexLogDebug("Command %s exited with status: %d", fullCmd.c_str(), status);
 
     // Execute post script associating to the sub-command if command is succeed
     if (status == EXIT_SUCCESS)
@@ -3001,7 +3001,7 @@ MainLicenseCheck(int argc, char** argv)
     if (argc >= 3)
         license = std::string(argv[2]);
 
-    HexLogNotice("Checking license App(%s) File(%s)", app.c_str(), license.c_str());
+    HexLogDebug("Checking license App(%s) File(%s)", app.c_str(), license.c_str());
     int result = LicenseCheck(app, license);
     if (result > 0) {
         printf("%d", result);


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Fixes two of the seven steady-state syslog floods root-caused in bigstack-oss/cubecos#1103 (a healthy idle HA node logs ~250 lines/min; these two account for ~19%):

- **DumpInterface** up-probed every admin-down NIC (`ip link set up` → kernel `8021q: adding VLAN 0` + PHC register/remove → probe → down) on every invocation. cube-cos-api polls it in `-f json` mode every 30s from every node. The json path now skips the probe and reports capability speed from the advertised link modes (readable while a NIC is down); the interactive CLI/installer path keeps the live probe. Side win: API node syncs no longer stall up to 8s per down NIC (`wait_sec` only bounds the wait — it never prevented the logging).
- **license_check** logged three Notice/Info lines per probe on the ~40s health cycle (equivalently noisy licensed or not). Expected states + the generic per-command "exited with status" dispatcher line drop to Debug; alarm states (compromised / bad signature / bad hardware / expired) remain Notice.

Both verified live on the sky lab cluster via runtime-equivalent hot-deploy: json DumpInterface adds zero kernel lines (interactive probe intact), license triplets 4.5/min → 0.

#### Which issue(s) this PR fixes

Fixes bigstack-oss/cubecos#1103 (partial — hex side; companion cubecos PR carries the template/config fixes and the submodule bump)

#### Special notes for your reviewer

> Verification evidence and the full seven-source analysis live in the handbook: `kb/cubecos/known-issues/steady-state-log-floods-corrections.md` (bigstack-handbook). Measurement pitfalls documented there too (dmesg ring-buffer saturation, rsyslog out-of-order blocks — use `dmesg -T` timestamps, not counts).

#### Additional documentation

```docs
Handbook: kb/cubecos/known-issues/steady-state-log-floods-corrections.md (PR in bigstack-handbook)
```