### PR TITLE
fix(sec): add missing SHA-1 removals to CUBE-HARDEN subpolicy

### DIFF
--- a/rootfs/Makefile
+++ b/rootfs/Makefile
@@ -139,7 +139,10 @@ base_rootfs_install:
 	$(Q)[ ! -e $(ROOTDIR)/etc/selinux/config ] || sed -i "s/^SELINUX=.*/SELINUX=disabled/" $(ROOTDIR)/etc/selinux/config
 	# SHA-1 kex/MAC removals moved into the CUBE-HARDEN crypto-policies subpolicy (makerootfs);
 	# only the sntrup761 alias (not emitted by the policy generator) is patched in post-generation
-	$(Q)sed -i -e 's/sntrup761x25519-sha512@openssh.com/sntrup761x25519-sha512,&/' $(ROOTDIR)/etc/crypto-policies/back-ends/{openssh,opensshserver}.config
+	$(Q)sed -i -e '/^KexAlgorithms /s/sntrup761x25519-sha512@openssh.com/sntrup761x25519-sha512,&/' $(ROOTDIR)/etc/crypto-policies/back-ends/{openssh,opensshserver}.config
+	# fail the build if the PQC KEX or the injected alias is missing from the generated policy
+	$(Q)grep -q 'mlkem768x25519-sha256' $(ROOTDIR)/etc/crypto-policies/back-ends/opensshserver.config
+	$(Q)grep -q 'sntrup761x25519-sha512,' $(ROOTDIR)/etc/crypto-policies/back-ends/opensshserver.config
 
 $(call HEX_CHECKROOTFS,$(HEX_BASE_ROOTFS))
 

--- a/scripts/makerootfs
+++ b/scripts/makerootfs
@@ -243,11 +243,14 @@ key_exchange@SSH = +SNTRUP
 group@SSH = +MLKEM768-X25519
 EOF
     # issue#77: ssh-audit hardening — drop NIST-curve/group14 KEX, ssh-rsa and
-    # ecdsa-nistp521 host keys, non-ETM MACs; add aes192-ctr (SSH scope only)
+    # ecdsa-nistp521 host keys, SHA-1 (gex-sha1, hmac-sha1) and non-ETM MACs;
+    # add aes192-ctr (SSH scope only)
     cat <<EOF >$ROOTDIR/etc/crypto-policies/policies/modules/CUBE-HARDEN.pmod
 cipher@SSH = +AES-192-CTR
 group@SSH = -SECP256R1 -SECP384R1 -SECP521R1 -FFDHE-2048
 sign@SSH = -RSA-SHA1 -ECDSA-SHA2-512
+mac@SSH = -HMAC-SHA1
+hash@SSH = -SHA1
 etm@SSH = DISABLE_NON_ETM
 EOF
     chroot $ROOTDIR sh -c 'update-crypto-policies --set DEFAULT:SHA1:CUBE-PQ:CUBE-HARDEN'


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

Follow-up to #128 (merged): the PR description promised `hash@SSH = -SHA1`
and `mac@SSH = -HMAC-SHA1` in `CUBE-HARDEN.pmod`, but the committed heredoc
was an earlier 4-line iteration — the directives existed only in the
verified test artifact on the dev VM, not in the script. Since the same
commit removed the old Makefile seds that used to strip these algorithms,
a build from current develop would re-offer `diffie-hellman-group-exchange-sha1`
and `hmac-sha1-etm@openssh.com` on the wire.

This adds the two missing directives, and hardens the alias injection per
the post-merge review on #128:

- anchor the sntrup761 alias sed to lines starting with `KexAlgorithms `
- add build-time grep assertions after generation (PQC KEX present,
  unsuffixed alias injected) — a silent regression now fails the image build

Re-verified via a generator dry-build of the fixed policy chain:
gex-sha1 / hmac-sha1 occurrences drop to zero; `MACs` reduces to the three
ETM variants; `KexAlgorithms` head is
`sntrup761x25519-sha512,sntrup761x25519-sha512@openssh.com,mlkem768x25519-sha256,…`
with the classic fallback intact; both assertions pass.

#### Which issue(s) this PR fixes

Ref bigstack-oss/cubecos-private#77 (regression fix for #128)

#### Special notes for your reviewer

> Note
>
> Caught by the post-merge review on #128 — thanks. Root cause was a
> divergence between the tested artifact (pmod written directly on the dev
> VM during verification) and the committed script; the new build-time
> assertions exist precisely to make this class of divergence fail loudly.

#### Additional documentation

```docs
man crypto-policies(7) — hash/mac scoped directives
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
