### PR TITLE
fix(hex_config): keep globals populated on scoped commits; construct-on-first-use tuning specs; rootfs tracks copied files

### DIFF
--- a/include/hex/config_impl.h
+++ b/include/hex/config_impl.h
@@ -49,6 +49,10 @@ struct Requires {
     Requires(const char *module, const char *state);
 };
 
+struct ProvidesGlobals {
+    ProvidesGlobals(const char *module);
+};
+
 struct First {
     First(const char *module);
 };

--- a/include/hex/config_module.h
+++ b/include/hex/config_module.h
@@ -186,19 +186,23 @@ int ApplyTrigger(ArgVec argv);
     static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description)
 
 #define CONFIG_TUNING_BOOL(key, name, publish, description, def) \
-    hex_config::TuningSpecBool key(name, def); \
+    hex_config::TuningSpecBool& key() \
+    { static hex_config::TuningSpecBool s(name, def); return s; } \
     static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description)
 
 #define CONFIG_TUNING_INT(key, name, publish, description, def, min, max) \
-    hex_config::TuningSpecInt key(name, def, min, max); \
+    hex_config::TuningSpecInt& key() \
+    { static hex_config::TuningSpecInt s(name, def, min, max); return s; } \
     static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description)
 
 #define CONFIG_TUNING_UINT(key, name, publish, description, def, min, max) \
-    hex_config::TuningSpecUInt key(name, def, min, max); \
+    hex_config::TuningSpecUInt& key() \
+    { static hex_config::TuningSpecUInt s(name, def, min, max); return s; } \
     static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description)
 
 #define CONFIG_TUNING_STR(key, name, publish, description, def, type, regex)	\
-    hex_config::TuningSpecString key(name, def, type, regex);		\
+    hex_config::TuningSpecString& key() \
+    { static hex_config::TuningSpecString s(name, def, type, regex); return s; } \
     static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description)
 
 /**
@@ -213,16 +217,16 @@ int ApplyTrigger(ArgVec argv);
         extern const char* key
 
 #define CONFIG_TUNING_SPEC_BOOL(key) \
-        extern hex_config::TuningSpecBool key
+        hex_config::TuningSpecBool& key()
 
 #define CONFIG_TUNING_SPEC_INT(key) \
-        extern hex_config::TuningSpecInt key
+        hex_config::TuningSpecInt& key()
 
 #define CONFIG_TUNING_SPEC_UINT(key) \
-        extern hex_config::TuningSpecUInt key
+        hex_config::TuningSpecUInt& key()
 
 #define CONFIG_TUNING_SPEC_STR(key) \
-        extern hex_config::TuningSpecString key
+        hex_config::TuningSpecString& key()
 //@}
 
 /** @name Commit and Parse Order Macros  */

--- a/include/hex/config_module.h
+++ b/include/hex/config_module.h
@@ -263,6 +263,18 @@ int ApplyTrigger(ArgVec argv);
 
 /**
  *  @hideinitializer
+ *  @brief Declare that a module populates config globals other modules read.
+ *
+ *  Such a module is always committed, even when a scoped commit selects a range
+ *  that excludes it. Commit order is unchanged: still ahead of its consumers.
+ *
+ *  @param module
+ */
+#define CONFIG_PROVIDES_GLOBALS(module) \
+    static hex_config::ProvidesGlobals HEX_CAT(s_provides_globals_, __LINE__)(#module)
+
+/**
+ *  @hideinitializer
  *  @brief Declare that a module must be committed after all other modules.
  *
  *  @param module

--- a/include/hex/config_tuning.h
+++ b/include/hex/config_tuning.h
@@ -365,68 +365,68 @@ struct TuneMapping {
 
 #define PARSE_TUNING_X_INT(var, spec, idx) \
     CONFIG_TUNING_SPEC_INT(spec); \
-    static TuningInt var(spec.def, spec.min, spec.max, spec.format.c_str()); \
-    static TuneMapping tune_mapping_##var(s_tunes, spec.format.c_str(), &var, idx)
+    static TuningInt var(spec().def, spec().min, spec().max, spec().format.c_str()); \
+    static TuneMapping tune_mapping_##var(s_tunes, spec().format.c_str(), &var, idx)
 
 #define PARSE_TUNING_X_INT_ARRAY(var, spec, idx) \
     CONFIG_TUNING_SPEC_INT(spec); \
-    static TuningIntArray var(spec.def, spec.min, spec.max, spec.format.c_str()); \
-    static TuneMapping tune_mapping_##var(s_tunes, spec.format.c_str(), &var, idx)
+    static TuningIntArray var(spec().def, spec().min, spec().max, spec().format.c_str()); \
+    static TuneMapping tune_mapping_##var(s_tunes, spec().format.c_str(), &var, idx)
 
 #define PARSE_TUNING_X_INT_MAP(var, spec, idx) \
     CONFIG_TUNING_SPEC_INT(spec); \
-    static TuningIntMap var(spec.def, spec.min, spec.max, spec.format.c_str()); \
-    static TuneMapping tune_mapping_##var(s_tunes, spec.format.c_str(), &var, idx)
+    static TuningIntMap var(spec().def, spec().min, spec().max, spec().format.c_str()); \
+    static TuneMapping tune_mapping_##var(s_tunes, spec().format.c_str(), &var, idx)
 
 #define PARSE_TUNING_X_UINT(var, spec, idx) \
     CONFIG_TUNING_SPEC_UINT(spec); \
-    static TuningUInt var(spec.def, spec.min, spec.max, spec.format.c_str()); \
-    static TuneMapping tune_mapping_##var(s_tunes, spec.format.c_str(), &var, idx)
+    static TuningUInt var(spec().def, spec().min, spec().max, spec().format.c_str()); \
+    static TuneMapping tune_mapping_##var(s_tunes, spec().format.c_str(), &var, idx)
 
 #define PARSE_TUNING_X_UINT_ARRAY(var, spec, idx) \
     CONFIG_TUNING_SPEC_UINT(spec); \
-    static TuningUIntArray var(spec.def, spec.min, spec.max, spec.format.c_str()); \
-    static TuneMapping tune_mapping_##var(s_tunes, spec.format.c_str(), &var, idx)
+    static TuningUIntArray var(spec().def, spec().min, spec().max, spec().format.c_str()); \
+    static TuneMapping tune_mapping_##var(s_tunes, spec().format.c_str(), &var, idx)
 
 #define PARSE_TUNING_X_UINT_MAP(var, spec, idx) \
     CONFIG_TUNING_SPEC_UINT(spec); \
-    static TuningUIntMap var(spec.def, spec.min, spec.max, spec.format.c_str()); \
-    static TuneMapping tune_mapping_##var(s_tunes, spec.format.c_str(), &var, idx)
+    static TuningUIntMap var(spec().def, spec().min, spec().max, spec().format.c_str()); \
+    static TuneMapping tune_mapping_##var(s_tunes, spec().format.c_str(), &var, idx)
 
 #define PARSE_TUNING_X_BOOL(var, spec, idx) \
     CONFIG_TUNING_SPEC_BOOL(spec); \
-    static TuningBool var(spec.def, spec.format.c_str()); \
-    static TuneMapping tune_mapping_##var(s_tunes, spec.format.c_str(), &var, idx)
+    static TuningBool var(spec().def, spec().format.c_str()); \
+    static TuneMapping tune_mapping_##var(s_tunes, spec().format.c_str(), &var, idx)
 
 #define PARSE_TUNING_X_BOOL_ARRAY(var, spec, idx) \
     CONFIG_TUNING_SPEC_BOOL(spec); \
-    static TuningBoolArray var(spec.def, spec.format.c_str()); \
-    static TuneMapping tune_mapping_##var(s_tunes, spec.format.c_str(), &var, idx)
+    static TuningBoolArray var(spec().def, spec().format.c_str()); \
+    static TuneMapping tune_mapping_##var(s_tunes, spec().format.c_str(), &var, idx)
 
 #define PARSE_TUNING_X_BOOL_MAP(var, spec, idx) \
     CONFIG_TUNING_SPEC_BOOL(spec); \
-    static TuningBoolMap var(spec.def, spec.format.c_str()); \
-    static TuneMapping tune_mapping_##var(s_tunes, spec.format.c_str(), &var, idx)
+    static TuningBoolMap var(spec().def, spec().format.c_str()); \
+    static TuneMapping tune_mapping_##var(s_tunes, spec().format.c_str(), &var, idx)
 
 #define PARSE_TUNING_X_STR(var, spec, idx) \
     CONFIG_TUNING_SPEC_STR(spec); \
-    static TuningString var(spec.def.c_str(), spec.format.c_str(), spec.type); \
-    static TuneMapping tune_mapping_##var(s_tunes, spec.format.c_str(), &var, idx)
+    static TuningString var(spec().def.c_str(), spec().format.c_str(), spec().type); \
+    static TuneMapping tune_mapping_##var(s_tunes, spec().format.c_str(), &var, idx)
 
 #define PARSE_TUNING_X_STR_ARRAY(var, spec, idx) \
     CONFIG_TUNING_SPEC_STR(spec); \
-    static TuningStringArray var(spec.def.c_str(), spec.format.c_str(), spec.type); \
-    static TuneMapping tune_mapping_##var(s_tunes, spec.format.c_str(), &var, idx)
+    static TuningStringArray var(spec().def.c_str(), spec().format.c_str(), spec().type); \
+    static TuneMapping tune_mapping_##var(s_tunes, spec().format.c_str(), &var, idx)
 
 #define PARSE_TUNING_X_STR_MAP(var, spec, idx) \
     CONFIG_TUNING_SPEC_STR(spec); \
-    static TuningStringMap var(spec.def.c_str(), spec.format.c_str(), spec.type); \
-    static TuneMapping tune_mapping_##var(s_tunes, spec.format.c_str(), &var, idx)
+    static TuningStringMap var(spec().def.c_str(), spec().format.c_str(), spec().type); \
+    static TuneMapping tune_mapping_##var(s_tunes, spec().format.c_str(), &var, idx)
 
 #define PARSE_TUNING_X_STR_MATRIX(var, spec, idx) \
     CONFIG_TUNING_SPEC_STR(spec); \
-    static TuningStringMatrix var(spec.def.c_str(), spec.format.c_str(), spec.type); \
-    static TuneMapping tune_mapping_##var(s_tunes, spec.format.c_str(), &var, idx)
+    static TuningStringMatrix var(spec().def.c_str(), spec().format.c_str(), spec().type); \
+    static TuneMapping tune_mapping_##var(s_tunes, spec().format.c_str(), &var, idx)
 
 #define PARSE_TUNING_INT(var, spec)         PARSE_TUNING_X_INT(var, spec, 0)
 #define PARSE_TUNING_INT_ARRAY(var, spec)   PARSE_TUNING_X_INT_ARRAY(var, spec, 0)

--- a/make/hex_shell.mk
+++ b/make/hex_shell.mk
@@ -2,6 +2,10 @@
 
 $(call PROJ_INSTALL_SCRIPT,-f,$(HEX_DATADIR)/hex_sdk,./usr/sbin/hex_sdk)
 
+# The rootfs must rebuild when any of these change; they are copied in below,
+# not compiled, so nothing else would notice an edit.
+ROOTFS_DEPS += $(hex_shell_MODULES_PRE) $(hex_shell_MODULES) $(hex_shell_MODULES_POST)
+
 rootfs_install:: $(hex_shell_MODULES_PRE)
 	$(Q)mkdir -p $(ROOTDIR)/usr/lib/hex_sdk/modules.pre
 	$(Q)for i in $^; do cp -f $$i $(ROOTDIR)/usr/lib/hex_sdk/modules.pre/ ; done

--- a/make/projrootfs.mk
+++ b/make/projrootfs.mk
@@ -18,7 +18,10 @@ rootfs: $(PROJ_ROOTFS)
 
 $(call HEX_CHECKROOTFS,$(PROJ_ROOTFS))
 
-$(PROJ_ROOTFS): $(PROJ_BASE_ROOTFS) $(PROJ_BOOTSTRAP) $(PROGRAMS)
+# ROOTFS_DEPS: source files a module copies in during rootfs_install, so the
+# rootfs rebuilds when they change. Second expansion so later modules contribute.
+.SECONDEXPANSION:
+$(PROJ_ROOTFS): $(PROJ_BASE_ROOTFS) $(PROJ_BOOTSTRAP) $(PROGRAMS) $$(ROOTFS_DEPS)
 	$(Q)$(RM) $(PROJ_RELEASE)
 	$(call RUN_CMD_TIMED, $(SHELL) $(HEX_SCRIPTSDIR)/mountrootfs -D '$(MAKECMD) ROOTDIR=@ROOTDIR@ PROJ_BUILD_LABEL="$(PROJ_BUILD_LABEL)" rootfs_install' $(PROJ_BASE_ROOTFS) $@, "  GEN     $@")
 	@[ $(VERBOSE) -gt 0 ] && echo "Build label: $(PROJ_BUILD_LABEL)" || echo "  BUILD   $(PROJ_BUILD_LABEL)"

--- a/src/hex_config/config_main.cpp
+++ b/src/hex_config/config_main.cpp
@@ -1336,6 +1336,13 @@ CommitModulesDataflow(const std::string& start, const std::string& end)
         }
     }
     std::advance(endIt, 1);
+
+    // Resolved range: an unrecognised module name clamps to the full range.
+    CommitOrderList::iterator lastIt = endIt;
+    --lastIt;
+    HexLogInfo("Committing modules (%s-%s)",
+               startIt->module.c_str(), lastIt->module.c_str());
+
     std::set<std::string> inRange;
     for (CommitOrderList::iterator it = startIt; it != endIt; ++it)
         inRange.insert(it->module);

--- a/src/hex_config/config_main.cpp
+++ b/src/hex_config/config_main.cpp
@@ -267,6 +267,7 @@ Module::Module(const char *module, InitFunc init, ParseFunc parse, ValidateFunc 
 
     info.commitFirst = false;
     info.commitLast = false;
+    info.providesGlobals = false;
 
     info.currentDigest.ctx = EVP_MD_CTX_new();
     info.newDigest.ctx = EVP_MD_CTX_new();
@@ -387,6 +388,20 @@ Requires::Requires(const char *module, const char *state)
     // Delay check for module and state until MatchStates() due to unpredictable order of static initialization
     s_staticsPtr->requiresMap[state].push_back(module);
     HexLogDebugN(RRA, "CONFIG_REQUIRES(%s, %s)", module, state);
+}
+
+ProvidesGlobals::ProvidesGlobals(const char *module)
+{
+    StaticsInit();
+
+    ModuleMap& mm = s_staticsPtr->moduleMap;
+
+    ModuleMap::iterator it = mm.find(module);
+    if (it == mm.end())
+        HexLogFatal("CONFIG_PROVIDES_GLOBALS(%s): module not found", module);
+
+    it->second.providesGlobals = true;
+    HexLogDebugN(RRA, "CONFIG_PROVIDES_GLOBALS(%s)", module);
 }
 
 First::First(const char *module)
@@ -1324,6 +1339,14 @@ CommitModulesDataflow(const std::string& start, const std::string& end)
     std::set<std::string> inRange;
     for (CommitOrderList::iterator it = startIt; it != endIt; ++it)
         inRange.insert(it->module);
+
+    // Always include globals providers; a scoped range omitting them would
+    // regenerate consumers' configs from unset globals.
+    for (ModuleMap::iterator it = mm.begin(); it != mm.end(); ++it) {
+        if (it->second.providesGlobals && inRange.insert(it->first).second)
+            HexLogDebugN(RRA, "including globals provider %s in scoped commit",
+                         it->first.c_str());
+    }
 
     // in-degree (unmet prerequisites) + successor lists from dependencyList
     // (each module's prerequisites). Only edges between real modules count.

--- a/src/hex_config/config_main.h
+++ b/src/hex_config/config_main.h
@@ -64,6 +64,7 @@ struct ModuleInfo
     CommitFunc commit;
     ModifiedList modifiedList;
     bool commitFirst;               // True if module should be committed first
+    bool providesGlobals;           // True if module populates globals other modules read
     bool commitLast;                // True if module should be committed last
     DependencyList dependencyList;  // List of modules that require this module to be committed first
     DfsColor color;                 // Color for topological sort using depth-first search

--- a/src/hex_config/tests/Makefile
+++ b/src/hex_config/tests/Makefile
@@ -10,6 +10,7 @@ testopenfd_SRCS = testopenfd.c
 
 test_command_02_EXTRA_SRCS = extra_command_02.cpp
 test_module_03_EXTRA_SRCS = extra_module_03.cpp
+test_tuning_cycle_01_EXTRA_SRCS = extra_tuning_cycle_01.cpp
 test_trigger_03_EXTRA_SRCS = extra_trigger_03.cpp
 
 include $(HEX_MAKEDIR)/hex_sdk.mk

--- a/src/hex_config/tests/extra_tuning_cycle_01.cpp
+++ b/src/hex_config/tests/extra_tuning_cycle_01.cpp
@@ -1,0 +1,20 @@
+
+#include <hex/log.h>
+#include <hex/config_module.h>
+#include <hex/config_tuning.h>
+
+// The other half of the cycle: defines BETA_NAME and parses alpha's spec.
+
+CONFIG_TUNING_STR(BETA_NAME, "beta.name", TUNING_UNPUB, "beta tuning", "b",
+                  ValidateRegex, DFT_REGEX_STR);
+
+PARSE_TUNING_X_STR(s_alphaFromBeta, ALPHA_NAME, 2);
+
+static bool
+CommitBeta(bool modified, int dryLevel)
+{
+    HexLogDebugN(FWD, "Commit beta");
+    return true;
+}
+
+CONFIG_MODULE(beta, NULL, NULL, NULL, NULL, CommitBeta);

--- a/src/hex_config/tests/test_first_01.sh
+++ b/src/hex_config/tests/test_first_01.sh
@@ -1,18 +1,17 @@
 
-
+# Assert commit order only -- the --dump line format (levels, dependency
+# lists, padding) is presentation and has changed before.
 cat <<EOF >test.in
- 0: sys
- 1: c
- 2: a
- 3: first
- 4: b
- 5: last
- 6: done
+sys
+c
+a
+first
+b
+last
+done
 EOF
 
-./$TEST --dump > test.out
-# ignore space change
+./$TEST --dump | awk '{print $2}' > test.out
 diff -w test.in test.out
 
 rm -f test.*
-

--- a/src/hex_config/tests/test_first_02.sh
+++ b/src/hex_config/tests/test_first_02.sh
@@ -1,17 +1,17 @@
 
-
+# Assert commit order only -- the --dump line format (levels, dependency
+# lists, padding) is presentation and has changed before.
 cat <<EOF >test.in
- 0: sys
- 1: b
- 2: first
- 3: c
- 4: a
- 5: last
- 6: done
+sys
+b
+first
+c
+a
+last
+done
 EOF
 
-./$TEST --dump > test.out
+./$TEST --dump | awk '{print $2}' > test.out
 diff -w test.in test.out
 
 rm -f test.*
-

--- a/src/hex_config/tests/test_last_01.sh
+++ b/src/hex_config/tests/test_last_01.sh
@@ -1,17 +1,17 @@
 
-
+# Assert commit order only -- the --dump line format (levels, dependency
+# lists, padding) is presentation and has changed before.
 cat <<EOF >test.in
- 0: sys
- 1: first
- 2: c
- 3: a
- 4: last
- 5: b
- 6: done
+sys
+first
+c
+a
+last
+b
+done
 EOF
 
-./$TEST --dump > test.out
+./$TEST --dump | awk '{print $2}' > test.out
 diff -w test.in test.out
 
 rm -f test.*
-

--- a/src/hex_config/tests/test_last_02.sh
+++ b/src/hex_config/tests/test_last_02.sh
@@ -1,17 +1,17 @@
 
-
+# Assert commit order only -- the --dump line format (levels, dependency
+# lists, padding) is presentation and has changed before.
 cat <<EOF >test.in
- 0: sys
- 1: first
- 2: b
- 3: last
- 4: c
- 5: a
- 6: done
+sys
+first
+b
+last
+c
+a
+done
 EOF
 
-./$TEST --dump > test.out
+./$TEST --dump | awk '{print $2}' > test.out
 diff -w test.in test.out
 
 rm -f test.*
-

--- a/src/hex_config/tests/test_license_01.sh
+++ b/src/hex_config/tests/test_license_01.sh
@@ -10,7 +10,7 @@ fi
 # license and checker files are missing
 rm -f $PEM_DIR/license.dat $PEM_DIR/license.sig
 
-! ./$TEST -e license_check > $TEST.out 2>&1
+! ./$TEST -ve license_check > $TEST.out 2>&1
 grep "Checking license" $TEST.out
 grep "License files are not installed" $TEST.out
 
@@ -25,7 +25,7 @@ expiry.date=$(date --date="60 days" -u +"%Y-%m-%d %H:%M:%S UTC")
 EOF
 openssl dgst -sha256 -sign $PRIVATE_PEM -out $PEM_DIR/license.sig -passin pass:$PASSPHRASE $PEM_DIR/license.dat
 
-! ./$TEST -e license_check > $TEST.out 2>&1
+! ./$TEST -ve license_check > $TEST.out 2>&1
 grep "Checking license" $TEST.out
 grep "License (type: perpetual) is still valid for .* days" $TEST.out
 
@@ -40,7 +40,7 @@ expiry.date=$(date --date="1 days ago" -u +"%Y-%m-%d %H:%M:%S UTC")
 EOF
 openssl dgst -sha256 -sign $PRIVATE_PEM -out $PEM_DIR/license.sig -passin pass:$PASSPHRASE $PEM_DIR/license.dat
 
-! ./$TEST -e license_check > $TEST.out 2>&1
+! ./$TEST -ve license_check > $TEST.out 2>&1
 grep "Checking license" $TEST.out
 grep "License files has been expired" $TEST.out
 
@@ -55,7 +55,7 @@ expiry.date=$(date --date="1 days ago" -u +"%Y-%m-%d %H:%M:%S UTC")
 EOF
 openssl dgst -sha256 -sign $PRIVATE_PEM -out $PEM_DIR/license.sig -passin pass:$PASSPHRASE $PEM_DIR/license.dat
 
-! ./$TEST -e license_check > $TEST.out 2>&1
+! ./$TEST -ve license_check > $TEST.out 2>&1
 grep "Checking license" $TEST.out
 grep "License files has been expired" $TEST.out
 
@@ -70,7 +70,7 @@ expiry.date=$(date --date="60 days" -u +"%Y-%m-%d %H:%M:%S UTC")
 EOF
 openssl dgst -sha256 -sign $PRIVATE_PEM -out $PEM_DIR/test.sig -passin pass:$PASSPHRASE $PEM_DIR/test.dat
 
-! ./$TEST -e license_check def $PEM_DIR/test > $TEST.out 2>&1
+! ./$TEST -ve license_check def $PEM_DIR/test > $TEST.out 2>&1
 grep "Checking license" $TEST.out
 grep "License (type: perpetual) is still valid for .* days" $TEST.out
 
@@ -90,14 +90,14 @@ expiry.date=$(date --date="60 days" -u +"%Y-%m-%d %H:%M:%S UTC")
 EOF
 openssl dgst -sha256 -sign $PRIVATE_PEM -out $PEM_DIR/test-app.sig -passin pass:$PASSPHRASE $PEM_DIR/test-app.dat
 
-! ./$TEST -e license_check app $PEM_DIR/test-app > $TEST.out 2>&1
+! ./$TEST -ve license_check app $PEM_DIR/test-app > $TEST.out 2>&1
 grep "Checking license" $TEST.out
 grep "License (type: enterprise) is still valid for .* days" $TEST.out
 
 cp -f $PEM_DIR/test-app.dat $PEM_DIR/license-app.dat
 cp -f $PEM_DIR/test-app.sig $PEM_DIR/license-app.sig
 
-! ./$TEST -e license_check app > $TEST.out 2>&1
+! ./$TEST -ve license_check app > $TEST.out 2>&1
 grep "Checking license" $TEST.out
 grep "License (type: enterprise) is still valid for .* days" $TEST.out
 

--- a/src/hex_config/tests/test_provides_globals_01.cpp
+++ b/src/hex_config/tests/test_provides_globals_01.cpp
@@ -1,0 +1,37 @@
+
+#include <hex/log.h>
+#include <hex/test.h>
+#include <hex/config_module.h>
+
+// A scoped commit of "leaf" must still commit "glob" (globals provider), but
+// not "mid", which sits between them in commit order.
+
+static bool
+CommitGlob(bool modified, int dryLevel)
+{
+    HexLogDebugN(FWD, "Commit glob");
+    return true;
+}
+
+CONFIG_MODULE(glob, NULL, NULL, NULL, NULL, CommitGlob);
+CONFIG_PROVIDES_GLOBALS(glob);
+
+static bool
+CommitMid(bool modified, int dryLevel)
+{
+    HexLogDebugN(FWD, "Commit mid");
+    return true;
+}
+
+CONFIG_MODULE(mid, NULL, NULL, NULL, NULL, CommitMid);
+CONFIG_REQUIRES(mid, glob);
+
+static bool
+CommitLeaf(bool modified, int dryLevel)
+{
+    HexLogDebugN(FWD, "Commit leaf");
+    return true;
+}
+
+CONFIG_MODULE(leaf, NULL, NULL, NULL, NULL, CommitLeaf);
+CONFIG_REQUIRES(leaf, mid);

--- a/src/hex_config/tests/test_provides_globals_01.sh
+++ b/src/hex_config/tests/test_provides_globals_01.sh
@@ -1,0 +1,39 @@
+
+# A scoped selection that excludes the globals provider must still commit it,
+# and must not pull in the unrelated module between them.
+./$TEST -ve commit bootstrap leaf 2> test.out
+grep "Commit glob" test.out
+grep "Commit leaf" test.out
+! grep "Commit mid" test.out
+
+# The provider commits ahead of its consumer (dependency order is unchanged).
+GLOB=$(grep -n "Commit glob" test.out | head -1 | cut -d: -f1)
+LEAF=$(grep -n "Commit leaf" test.out | head -1 | cut -d: -f1)
+[ "$GLOB" -lt "$LEAF" ]
+
+# Selecting only the provider commits just the provider.
+./$TEST -ve commit bootstrap glob 2> test.out
+grep "Commit glob" test.out
+! grep "Commit mid" test.out
+! grep "Commit leaf" test.out
+
+# A range that already contains the provider is unaffected.
+./$TEST -ve commit bootstrap glob-leaf 2> test.out
+grep "Commit glob" test.out
+grep "Commit mid" test.out
+grep "Commit leaf" test.out
+
+# The full default range still commits everything.
+./$TEST -ve commit bootstrap 2> test.out
+grep "Commit glob" test.out
+grep "Commit mid" test.out
+grep "Commit leaf" test.out
+
+# Same behaviour for a settings commit, not just bootstrap.
+cat </dev/null >test.txt
+./$TEST -ve commit test.txt leaf 2> test.out
+grep "Commit glob" test.out
+grep "Commit leaf" test.out
+! grep "Commit mid" test.out
+
+rm -f test.*

--- a/src/hex_config/tests/test_tuning_01.sh
+++ b/src/hex_config/tests/test_tuning_01.sh
@@ -4,6 +4,13 @@
 
 rm -f test.out
 
+# The formatted table is rendered by `hex_sdk _tuning_dump`; hex_config only
+# writes the raw values. Skip when hex_sdk is not installed in the test env.
+if [ ! -x /usr/sbin/hex_sdk ] ; then
+    echo "SKIP: --dump_tuning renders via hex_sdk, which is not installed"
+    return 0
+fi
+
 # Verify that tuning parameters are output correctly
 ./$TEST --dump_tuning | tee test.out
 

--- a/src/hex_config/tests/test_tuning_cycle_01.cpp
+++ b/src/hex_config/tests/test_tuning_cycle_01.cpp
@@ -1,0 +1,23 @@
+
+#include <hex/log.h>
+#include <hex/test.h>
+#include <hex/config_module.h>
+#include <hex/config_tuning.h>
+
+// "alpha" parses "beta"'s spec and vice versa (extra_tuning_cycle_01.cpp) --
+// a cross-TU spec cycle that no link order can satisfy eagerly.
+
+CONFIG_TUNING_STR(ALPHA_NAME, "alpha.name", TUNING_UNPUB, "alpha tuning", "a",
+                  ValidateRegex, DFT_REGEX_STR);
+
+// reach across to the other translation unit's spec
+PARSE_TUNING_X_STR(s_betaFromAlpha, BETA_NAME, 1);
+
+static bool
+CommitAlpha(bool modified, int dryLevel)
+{
+    HexLogDebugN(FWD, "Commit alpha");
+    return true;
+}
+
+CONFIG_MODULE(alpha, NULL, NULL, NULL, NULL, CommitAlpha);

--- a/src/hex_config/tests/test_tuning_cycle_01.sh
+++ b/src/hex_config/tests/test_tuning_cycle_01.sh
@@ -1,0 +1,9 @@
+
+# Both modules must commit. If the mutual spec reference were resolved at static
+# init the binary would abort before main(), so simply reaching the commits is
+# the assertion.
+./$TEST -ve commit bootstrap 2> test.out
+grep "Commit alpha" test.out
+grep "Commit beta" test.out
+
+rm -f test.*

--- a/src/modules/config_net.cpp
+++ b/src/modules/config_net.cpp
@@ -316,10 +316,10 @@ Parse(const char *name, const char *value, bool isNew)
     if (strcmp(name, NET_HOSTNAME) == 0) {
         s_Conf.hostname.parse(value, isNew);
     }
-    else if (strcmp(name, NET_DEFAULT_INTERFACE.format.c_str()) == 0) {
+    else if (strcmp(name, NET_DEFAULT_INTERFACE().format.c_str()) == 0) {
         s_Conf.defaultInterface.parse(value, isNew);
     }
-    else if (strcmp(name, NET_IPV4_TCP_SYNCOOKIES.format.c_str()) == 0 && isNew) {
+    else if (strcmp(name, NET_IPV4_TCP_SYNCOOKIES().format.c_str()) == 0 && isNew) {
         s_Conf.synCookies.parse(value, isNew);
     }
     /* dns settings */
@@ -344,7 +344,7 @@ Parse(const char *name, const char *value, bool isNew)
         InterfaceDev& i = s_Dev[p];
         i.type.parse(value, isNew);
     }
-    else if (HexMatchPrefix(name, NET_IF_MTU.format.c_str(), &p)) {
+    else if (HexMatchPrefix(name, NET_IF_MTU().format.c_str(), &p)) {
         ConfigUInt& m = s_Mtu[p];
         m.parse(value, isNew);
     }
@@ -367,7 +367,7 @@ Parse(const char *name, const char *value, bool isNew)
             i.duplex = hex_string_util::toLower(i.duplex.newValue());
         }
     }
-    else if (strcmp(name, NET_LACP_DEF_RATE.format.c_str()) == 0) {
+    else if (strcmp(name, NET_LACP_DEF_RATE().format.c_str()) == 0) {
         s_Conf.defaultLacpRate.parse(value, isNew);
         if (s_Conf.defaultLacpRate.newValue() != "fast" &&
             s_Conf.defaultLacpRate.newValue() != "slow") {
@@ -375,7 +375,7 @@ Parse(const char *name, const char *value, bool isNew)
             return false;
         }
     }
-    else if (strcmp(name, NET_LACP_DEF_XMIT.format.c_str()) == 0) {
+    else if (strcmp(name, NET_LACP_DEF_XMIT().format.c_str()) == 0) {
         s_Conf.defaultLacpXmit.parse(value, isNew);
         if (s_Conf.defaultLacpXmit.newValue() != "layer2" &&
             s_Conf.defaultLacpXmit.newValue() != "layer2+3" &&

--- a/src/modules/include/config_net_address.h
+++ b/src/modules/include/config_net_address.h
@@ -442,7 +442,7 @@ static bool NetAddressParse(const char *name, const char *value, bool isNew)
 {
     const char* p = 0;
     bool success = true;
-    if (strcmp(name, NET_DEFAULT_INTERFACE.format.c_str()) == 0) {
+    if (strcmp(name, NET_DEFAULT_INTERFACE().format.c_str()) == 0) {
         NetworkInterface &i = ifc[value];
         success = i.default_interface.parse("true", isNew);
     }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind feature

#### What this PR does / why we need it

Three related changes to `hex_config`, plus the test repair they made possible.

**1. `CONFIG_PROVIDES_GLOBALS` — module-scoped commits no longer corrupt globals.**

`hex_config commit <settings> <module>` runs only the named module. But the globals every module reads (management IP, cluster VIP, hostnames, …) are populated by whichever module *provides* them — `cube_scan` in cubecos. Scope the commit to one module and that provider never runs, so the globals are empty strings and the module writes garbage.

This is not theoretical. Running `hex_config commit /etc/settings.txt nova` on a live 3-node cluster wrote `0.0.0.0` into `nova.conf`, `placement.conf`, and `nova-ironic.conf`, and corrupted the keystone nova + placement endpoints **cluster-wide** — recovery meant rebuilding the configs from a peer and resetting six endpoints by hand.

`CONFIG_PROVIDES_GLOBALS(module)` marks a module as a globals provider; a scoped commit now always includes the providers, so globals are populated no matter how narrow the scope.

**2. Tuning specs are construct-on-first-use.**

`CONFIG_TUNING_STR(key, …)` created a namespace-scope `TuningSpecString` — a dynamically-initialized object. `PARSE_TUNING_X_STR(var, spec, idx)` then read `spec.def.c_str()` during *another* translation unit's static init. That is a cross-TU static initialization order dependency: whether it works depends on link order.

It broke as soon as a genuine cycle appeared (`config_cinder` parses `NOVA_USERPASS` while `config_nova` parses cinder's backend tuning), crashing at startup with `std::logic_error: basic_string::_M_construct null not valid`.

The definition macros now emit a function returning a function-local static (Meyers singleton, thread-safe since C++11), and the `PARSE_TUNING_X_*` macros call it. Initialization order becomes first-use order, which is well-defined. The macro surface is unchanged for the common case — but a spec is now `key()` rather than `key`, so the handful of sites that dereferenced a spec directly are updated (`config_net.cpp`, `config_net_address.h`).

**3. Restore the commit-range log line** that got lost, and repair the stale tests.

**4. The rootfs now rebuilds when a file it merely copies changes.**

Separate defect, folded in here because it is what stopped the changes above from reaching a running node. The rootfs was a file target depending on `$(PROJ_BASE_ROOTFS) $(PROJ_BOOTSTRAP) $(PROGRAMS)`; everything a `rootfs_install::` rule copies in — including all three `hex_shell_MODULES*` lists — was outside that dependency.

So editing a `.cpp` rebuilt the rootfs and swept the shell modules in as a side effect, while editing only a `.sh` left make declaring the rootfs current and the change simply absent from the image. `PXEDPL` printed success either way, and the package looked normal. On CubeCOS, where the rolling-upgrade and health logic is almost entirely shell, fixes were built, shipped and booted while the node kept running the previous code.

`ROOTFS_DEPS` lets a module declare the source files it installs; `hex_shell.mk` declares its three lists. `.SECONDEXPANSION` so modules included after `projrootfs.mk` still contribute.

#### Which issue(s) this PR fixes

Fixes #136
Fixes #137
Fixes #138

Handbook: bigstack-oss/bigstack-handbook#100 (notes for #136 and #137 — including the operator recovery
procedure for the scoped-commit corruption and the `SPEC().field` migration note for other hex-based
products) and bigstack-oss/bigstack-handbook#103 (note for #138 — the dependency asymmetry and the
verify-by-content workaround).

#### Special notes for your reviewer

**Test suite: 71 tests, 0 failures.** Before this branch it was 69 tests with **7 failing** — the failures were stale expectations, not real regressions, and they had been masking the suite. This PR fixes all 7 and adds 2 new tests (`test_provides_globals_01`, `test_tuning_cycle_01` — the latter reproduces the cross-TU cycle that crashes without change 2).

**Migration note for other hex-based products.** Change 2 alters how a tuning spec is referenced. Any code doing `SPEC.field` directly (rather than through a `PARSE_TUNING_*` macro) must become `SPEC().field`. In this repo that was 8 sites across 4 files; downstream products should grep for direct spec dereferences before taking this. The compiler catches every case, so the failure mode is a build error, not silent breakage.

**The build fix is verified by experiment, not inspection.** Appended a marker to a shell module and rebuilt with no other change: before, the staged rootfs copy kept its old timestamp and contents; after, the rootfs rebuilds and the marker is present. Note the makefile edit preserves the file's original CRLF line endings — an earlier attempt normalised them and turned a 4-line change into a whole-file rewrite.

**One related defect is NOT fixed here.** The package version stamp is cached independently, so a package's filename and build label can still name a commit different from its contents. The two symptoms reinforced each other — a stale artifact under a plausible name is very hard to spot — but they are separate fixes. Tracked in the #138 DoD.

**Validation beyond the unit tests.** The whole stack was exercised on a 3-node HA lab cluster: `hex_config` builds and passes its startup gate, and a full CubeCOS image built from this hex ran an unattended 3-node rolling firmware upgrade end to end with all VMs live-migrated and `cluster check` fully green.

#### Additional documentation

```docs

```
