### PR TITLE
feat(pxe): zero-touch installer preflight + phone-home-agent

### DIFF
--- a/data/hex_install/hex_autoinstall.sh.in
+++ b/data/hex_install/hex_autoinstall.sh.in
@@ -1,0 +1,152 @@
+#!/bin/bash
+#
+# Unattended appliance install for zero-touch deploy.
+#
+# Inert unless the kernel cmdline carries `autoinstall` (optionally
+# `autoinstall=/dev/sdX`). Called from the PXE installer's rc.local AFTER the
+# install .pkg has been fetched to /mnt/install. When armed, it restores the
+# image to the target disk non-interactively and reboots into the installed
+# system — the same operation an operator does by hand via `hex_pxe_install`,
+# just gated on a kernel arg so normal/manual installs are unaffected.
+#
+set -e
+
+# Mirror progress to the VGA (/dev/tty0 — the BMC KVM) and serial consoles.
+# /dev/tty0 is required: userspace writes to /dev/console only reach the last
+# console= (serial), never the VGA screen.
+say() { m="[autoinstall $(date +%H:%M:%S)] $*"; echo "$m" >> /run/autoinstall.log 2>/dev/null; echo "$m" | tee /dev/tty0 /dev/console >/dev/null 2>&1 || echo "$m"; }
+
+want=""
+disk=""
+for tok in $(cat /proc/cmdline); do
+    case "$tok" in
+        autoinstall) want=1 ;;
+        autoinstall=*) want=1; disk="${tok#autoinstall=}" ;;
+    esac
+done
+[ -n "$want" ] || exit 0
+
+say "AUTO-INSTALL MODE — press Alt-F2 / Alt-F3 for a login shell (root/admin) to investigate"
+
+# Reflect auto-install mode on the console login prompt (getty re-reads /etc/issue
+# per prompt). Set here — only when auto-install is armed — so a plain manual
+# install never shows it.
+printf '\n  *** AUTO-INSTALL MODE ***\n  A background job is installing this node (progress on tty1).\n  Press Alt-F2 / Alt-F3 here for a login shell to investigate.  Login: root / admin\n  Live progress: tail -f /run/autoinstall.log\n\n' > /etc/issue
+
+# Auto-detect the local system disk when not explicitly given: the first fixed,
+# non-removable, local disk. SAN/remote LUNs are skipped by transport
+# (HEX_INSTALL_SKIP_TRANSPORTS); a project can also skip its own data disks by
+# partition-label prefix (HEX_INSTALL_DATA_LABEL_PREFIX, empty = off).
+if [ -z "$disk" ] || [ "$disk" = "1" ]; then
+    disk=""
+    for d in /sys/block/sd* /sys/block/nvme*; do
+        [ -e "$d" ] || continue
+        n=$(basename "$d")
+        [ "$(cat "$d/removable" 2>/dev/null)" = "1" ] && continue
+        # Skip SAN/remote LUNs by transport (local OS disks are sata/nvme/sas).
+        tran=$(/bin/lsblk -dno TRAN "/dev/$n" 2>/dev/null)
+        if [ -n "$tran" ]; then
+            case " @HEX_INSTALL_SKIP_TRANSPORTS@ " in *" $tran "*) continue ;; esac
+        fi
+        # Skip disks carrying a project data-partition label (e.g. OSD disks).
+        if [ -n "@HEX_INSTALL_DATA_LABEL_PREFIX@" ] && /bin/lsblk -no PARTLABEL "/dev/$n" 2>/dev/null | grep -q "^@HEX_INSTALL_DATA_LABEL_PREFIX@"; then
+            continue
+        fi
+        disk="/dev/$n"
+        break
+    done
+fi
+
+if [ -z "$disk" ]; then
+    say "no eligible target disk found; leaving installer at prompt"
+    exit 1
+fi
+
+# Optional pre-restore hook: when driver_server= is set and a preflight agent is
+# installed, run it and abort on non-zero exit — validate before reimaging.
+# What the agent checks is the deploy driver's concern.
+driver_server=""
+for tok in $(cat /proc/cmdline); do
+    case "$tok" in
+        driver_server=*) driver_server="${tok#driver_server=}" ;;
+    esac
+done
+if [ -n "$driver_server" ] && [ -x /usr/sbin/phone-home-agent ]; then
+    # Ensure the tools/modules the preflight needs are present in the installer.
+    /usr/sbin/modprobe bonding 2>/dev/null || true
+    /usr/sbin/modprobe 8021q 2>/dev/null || true
+    /usr/sbin/modprobe ipmi_si 2>/dev/null || true
+    /usr/sbin/modprobe ipmi_devintf 2>/dev/null || true
+    say "network preflight: nic bringup + bond/vlan/ip + carrier + peer ping (waits for green light 1) ..."
+    SECONDS=0
+    if ! /usr/sbin/phone-home-agent --preflight --server "$driver_server"; then
+        say "PREFLIGHT FAILED (${SECONDS}s); leaving installer at prompt for inspection"
+        exit 1
+    fi
+    say "network preflight ... green light 1 (${SECONDS}s)"
+    # If the preflight agent stamped a target disk to /run/os-disk, it overrides
+    # the auto-detected disk above.
+    if [ -s /run/os-disk ]; then
+        picked=$(head -n1 /run/os-disk | tr -d '[:space:]')
+        if [ -b "$picked" ]; then
+            disk="$picked"
+            say "using appointed OS disk $disk (from snapshot server)"
+        else
+            say "appointed OS disk '$picked' is not a block device; keeping $disk"
+        fi
+    fi
+fi
+
+say "restoring $(basename "$disk") image to $disk ..."
+SECONDS=0
+echo "sys.install.hdd=$disk" > /etc/extra_settings.sys
+/usr/sbin/hex_install -v -w -t /etc/extra_settings.sys restore 2>&1 | tee /dev/tty0 /dev/console >/dev/null 2>&1
+rc=${PIPESTATUS[0]}
+if [ "$rc" != 0 ]; then
+    say "RESTORE FAILED (exit $rc, ${SECONDS}s) — leaving installer at prompt; check the .pkg fetch"
+    exit 1
+fi
+say "restore ... complete (${SECONDS}s)"
+
+# The kernel cmdline may not survive the reboot into the installed GRUB, so
+# persist driver_server= into the restored rootfs for the installed agent to
+# read (EnvironmentFile). Best effort.
+if [ -n "$driver_server" ]; then
+    mnt=/mnt/restored
+    mkdir -p "$mnt"
+    for part in $(/bin/lsblk -lnpo NAME "$disk" 2>/dev/null | tail -n +2); do
+        if mount "$part" "$mnt" 2>/dev/null; then
+            if [ -d "$mnt/etc/appliance" ]; then
+                mkdir -p "$mnt@HEX_AGENT_ENV_DIR@"
+                echo "DRIVER_SERVER=$driver_server" > "$mnt@HEX_AGENT_ENV_DIR@/phone-home-agent.env"
+                # Carry over any identity the preflight agent stamped for the
+                # installed agent to reuse.
+                if [ -f /run/phone-home-agent.env ]; then
+                    cat /run/phone-home-agent.env >> "$mnt@HEX_AGENT_ENV_DIR@/phone-home-agent.env"
+                fi
+                say "wrote snapshot server + identity to installed rootfs ($part)"
+                # /run does not survive the reboot but the rootfs does: carry any
+                # payload the agent pre-fetched during preflight into the rootfs.
+                if [ -f /run/appointed.snapshot ]; then
+                    mkdir -p "$mnt/var/support"
+                    if cp -f /run/appointed.snapshot "$mnt/var/support/appointed.snapshot"; then
+                        say "staged snapshot into rootfs for local apply ($(stat -c%s /run/appointed.snapshot 2>/dev/null) bytes)"
+                    fi
+                fi
+                umount "$mnt"
+                break
+            fi
+            umount "$mnt"
+        fi
+    done
+fi
+
+# While the preflight network is still up, notify the driver that the restore
+# finished, then reboot.
+if [ -n "$driver_server" ] && [ -x /usr/sbin/phone-home-agent ]; then
+    say "reporting restore-complete to $driver_server"
+    /usr/sbin/phone-home-agent --restore-done --server "$driver_server" || true
+fi
+
+say "install complete, rebooting into $disk"
+/sbin/reboot

--- a/data/hex_install/hex_pxe_fetch.sh.in
+++ b/data/hex_install/hex_pxe_fetch.sh.in
@@ -1,0 +1,73 @@
+#!/bin/bash
+# PXE installer image-fetch script — installed as /usr/sbin/hex_pxe_fetch and
+# invoked from rc.local. Fetches the install .pkg (HTTP from the company mirror
+# / pxeserver, or NFS via a pxe_via_nfs= cmdline arg), then hands off to
+# hex_autoinstall. The @TOKEN@ placeholders are substituted at build time.
+
+for i in $(cat /proc/cmdline); do if [[ $i =~ pxe_via_nfs= ]]; then eval $i ; fi ; done
+
+# Zero-touch diagnostics: on an unattended boot (autoinstall / driver_server=),
+# bring up sshd (root/admin) + spare-VT login shells so an operator can
+# investigate a headless install — remotely or via Alt-F2/F3 — while it runs on
+# tty1. Skipped on a plain manual install. Diagnostic aid, not hardened for prod.
+if grep -qw autoinstall /proc/cmdline || grep -q 'driver_server=' /proc/cmdline; then
+    echo root:admin | chpasswd 2>/dev/null || true
+    sed -i 's/^#*PermitRootLogin.*/PermitRootLogin yes/; s/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config 2>/dev/null || true
+    systemctl restart sshd 2>/dev/null || true
+    # --no-block: a waiting start from inside rc-local.service deadlocks the boot
+    # (rc-local waits on the getty job, whose ordering waits on boot completion).
+    systemctl --no-block start getty@tty2.service getty@tty3.service 2>/dev/null || true
+fi
+
+# Optional pre-fetch hook: if a deploy driver is configured, let the agent
+# decide whether to short-circuit this boot before fetching the image.
+if grep -q 'driver_server=' /proc/cmdline && [ -x /usr/sbin/phone-home-agent ]; then
+    echo '[rc.local] inspect-check (powers off here if this is an inspect boot) ...' | tee /dev/tty0 /dev/console >/dev/null 2>&1
+    /usr/sbin/phone-home-agent --inspect-check
+fi
+
+if [ -z ${pxe_via_nfs+x} ]; then
+    echo '[rc.local] waiting for pxeserver + fetching image via HTTP ...' | tee /dev/tty0 /dev/console >/dev/null 2>&1
+    SECONDS=0
+    for i in {1..10}; do
+        if timeout 2 ping -c 1 @HEX_COMPANY_DN@; then
+            timeout 7200 /usr/bin/wget -c -r -np --cut-dirs=3 -nH -R --show-progress -P /mnt/install -A "@PROJ_RELEASE_LONGNAME@*.pkg*" @HEX_COMPANY_DN@/ 2>&1 | tee /dev/tty0 >/dev/null 2>&1
+            break
+        elif timeout 2 ping -c 1 @PXESERVER_IP@; then
+            timeout 7200 /usr/bin/wget -c -r -np --cut-dirs=3 -nH -R --show-progress -P /mnt/install -A "@PROJ_RELEASE_LONGNAME@*.pkg*" @PXESERVER_IP@/ 2>&1 | tee /dev/tty0 >/dev/null 2>&1
+            break
+        else
+            sleep 1
+        fi
+    done
+    echo "[rc.local] image fetch via HTTP ... (${SECONDS}s)" | tee /dev/tty0 /dev/console >/dev/null 2>&1
+else
+    /bin/mkdir -p /mnt/nfs
+    # NetworkManager may not have the interface up when rc.local first runs, so
+    # the NFS mount must wait for the network AND retry — a one-shot mount races
+    # ahead of DHCP, leaving /mnt/nfs empty so rsync finds no pkg.
+    nfshost=${pxe_via_nfs%%:*}
+    for a in $(seq 1 60); do
+        grep -q " /mnt/nfs " /proc/mounts || { timeout 3 ping -c1 $nfshost >/dev/null 2>&1 && timeout 15 /bin/mount -t nfs -o nolock $pxe_via_nfs /mnt/nfs 2>/dev/null; }
+        pkg=$(basename $(ls /mnt/nfs/@PROJ_RELEASE_LONGNAME@*.pkg 2>/dev/null | head -1) 2>/dev/null)
+        [ -n "$pkg" ] && break
+        echo "[rc.local] waiting for network + NFS pkg (attempt $a) ..." | tee /dev/tty0 /dev/console >/dev/null 2>&1; sleep 3
+    done
+    echo "[rc.local] fetching ${pkg:-image} via NFS (retry until complete) ..." | tee /dev/tty0 /dev/console >/dev/null 2>&1
+    SECONDS=0
+    # --append resumes a killed transfer from the current length instead of a
+    # delta restart — safe because the source .pkg is static for a given name
+    # (a swapped pkg yields a corrupt file that hex_install rejects).
+    for a in $(seq 1 12); do
+        timeout 7200 /usr/bin/rsync --partial --append --info=progress2 /mnt/nfs/@PROJ_RELEASE_LONGNAME@*.pkg /mnt/install/ 2>&1 | tee /dev/tty0 >/dev/null 2>&1
+        [ ${PIPESTATUS[0]} -eq 0 ] && break
+        echo "[rc.local] ${pkg:-image} fetch attempt $a incomplete (${SECONDS}s); retrying" | tee /dev/tty0 /dev/console >/dev/null 2>&1; sleep 5
+    done
+    echo "[rc.local] ${pkg:-image} ... (${SECONDS}s)" | tee /dev/tty0 /dev/console >/dev/null 2>&1
+    sync
+    timeout 10 umount /mnt/nfs || umount -l /mnt/nfs
+fi
+
+# After the image is fetched, unattended-install if the kernel cmdline carries
+# `autoinstall` (inert otherwise).
+/usr/sbin/hex_autoinstall

--- a/make/hex_sdk_definitions.mk
+++ b/make/hex_sdk_definitions.mk
@@ -57,6 +57,14 @@ HEX_MIRROR        := $(shell ip r | grep default | cut -d" " -f3)
 HEX_PROXY_URL     := http://$(HEX_MIRROR):3128
 HEX_COMPANY_DN    := www.bigstack.co
 PXESERVER_IP      := 192.168.1.150
+# Installed-node directory for the phone-home agent's env file. Projects
+# override it in project.mk (e.g. cubecos uses /etc/cube).
+HEX_AGENT_ENV_DIR ?= /etc/appliance
+# Installer disk auto-detect: skip SAN/remote LUNs by transport (local OS disks
+# are sata/nvme/sas). Projects may also skip their own data disks by partition-
+# label prefix (empty = off); both overridable in project.mk.
+HEX_INSTALL_SKIP_TRANSPORTS   ?= fc iscsi fcoe
+HEX_INSTALL_DATA_LABEL_PREFIX ?=
 HEX_EXPORT_VARS += HEX_PKGDIR HEX_DISTDIR HEX_REPODIR HEX_OSSDIR HEX_THIRDPARTYDIR HEX_MIRROR HEX_PROXY_URL
 
 # Link dynamically against SDK if compiled for release

--- a/make/projpxe.mk
+++ b/make/projpxe.mk
@@ -29,7 +29,7 @@ pxe_build:
 	$(Q)nohup md5sum < $(PROJ_PXE) > $(PROJ_SHIPDIR)/$(PROJ_PXE_LONGNAME).md5 2>&1 &
 	$(Q)nohup sha256sum < $(PROJ_PXE) > $(PROJ_SHIPDIR)/$(PROJ_PXE_LONGNAME).sha256 2>&1 &
 
-$(PROJ_PXE_RD): $(HEX_PXE_RD) $(HEX_HWDETECT_FILES) $(PROJ_PPU) $(HEX_DATADIR)/hex_install/hex_pxe_install.sh.in
+$(PROJ_PXE_RD): $(HEX_PXE_RD) $(HEX_HWDETECT_FILES) $(PROJ_PPU) $(HEX_DATADIR)/hex_install/hex_pxe_install.sh.in $(HEX_DATADIR)/hex_install/hex_autoinstall.sh.in $(HEX_DATADIR)/hex_install/hex_pxe_fetch.sh.in
 	$(call RUN_CMD_TIMED,$(SHELL) $(HEX_SCRIPTSDIR)/mountinitramfs '$(MAKECMD) PPU=$$(readlink $(PROJ_RELEASE)).pkg ROOTDIR=@ROOTDIR@ pxe_ramdisk_install' $< $@,"  GEN     $@")
 
 pxe_ramdisk_install::
@@ -37,29 +37,22 @@ pxe_ramdisk_install::
 	$(Q)echo "if [ -d /sys/firmware/efi ]; then /usr/bin/hostname uefi-installer; else /usr/bin/hostname bios-installer; fi" >> $(ROOTDIR)/etc/rc.sysinit
 	$(Q)sed -e 's/@IMAGE_NAME@/$(PROJ_RELEASE_LONGNAME)\*.pkg/' $(HEX_DATADIR)/hex_install/hex_pxe_install.sh.in > $(ROOTDIR)/usr/sbin/hex_pxe_install
 	$(Q)chmod 755 $(ROOTDIR)/usr/sbin/hex_pxe_install
+	$(Q)sed -e 's|@HEX_AGENT_ENV_DIR@|$(HEX_AGENT_ENV_DIR)|g' -e 's|@HEX_INSTALL_DATA_LABEL_PREFIX@|$(HEX_INSTALL_DATA_LABEL_PREFIX)|g' -e 's|@HEX_INSTALL_SKIP_TRANSPORTS@|$(HEX_INSTALL_SKIP_TRANSPORTS)|g' $(HEX_DATADIR)/hex_install/hex_autoinstall.sh.in > $(ROOTDIR)/usr/sbin/hex_autoinstall
+	$(Q)chmod 755 $(ROOTDIR)/usr/sbin/hex_autoinstall
+	@# Ship the preflight agent into the installer so hex_autoinstall can run
+	@# --preflight before restore (agent binary provided by the build).
+	$(Q)if [ -f $(TOP_BLDDIR)/core/phone-home-agent/phone-home-agent ]; then \
+		cp -f $(TOP_BLDDIR)/core/phone-home-agent/phone-home-agent $(ROOTDIR)/usr/sbin/phone-home-agent && \
+		chmod 755 $(ROOTDIR)/usr/sbin/phone-home-agent ; \
+	else echo "  WARN    phone-home-agent not built; installer preflight disabled" ; fi
 	$(Q)chroot $(ROOTDIR) bash -c "rm -f /etc/systemd/system/NetworkManager.service"
 	$(Q)chroot $(ROOTDIR) bash -c "systemctl enable NetworkManager"
-	$(Q)echo "for i in \$$(cat /proc/cmdline); do if [[ \$$i =~ pxe_via_nfs= ]]; then eval \$$i ; fi ; done" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "if [ -z \$${pxe_via_nfs+x} ]; then" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "    for i in {1..10}; do" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "        if timeout 2 ping -c 1 $(HEX_COMPANY_DN); then" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "            timeout 180 /usr/bin/wget -r -np --cut-dirs=3 -nH -R --show-progress -P /mnt/install -A "$(PROJ_RELEASE_LONGNAME)\*.pkg*" $(HEX_COMPANY_DN)/" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "            break" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "        elif timeout 2 ping -c 1 $(PXESERVER_IP); then" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "            timeout 180 /usr/bin/wget -r -np --cut-dirs=3 -nH -R --show-progress -P /mnt/install -A "$(PROJ_RELEASE_LONGNAME)\*.pkg*" $(PXESERVER_IP)/" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "            break" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "        else" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "            sleep 1" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "        fi" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "    done" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "else" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "    /bin/mkdir -p /mnt/nfs" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "    timeout 10 /bin/mount -t nfs -o nolock \$$pxe_via_nfs /mnt/nfs" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "    timeout 180 /usr/bin/rsync --progress /mnt/nfs/$(PROJ_RELEASE_LONGNAME)*.pkg /mnt/install/" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "    sync" >> $(ROOTDIR)/etc/rc.d/rc.local
-	$(Q)echo "    timeout 10 umount /mnt/nfs || umount -l /mnt/nfs" >> $(ROOTDIR)/etc/rc.d/rc.local
+	@# Ship the image-fetch + autoinstall logic as a standalone script; rc.local
+	@# only invokes it. @TOKEN@ placeholders are filled at build time.
+	$(Q)sed -e 's|@HEX_COMPANY_DN@|$(HEX_COMPANY_DN)|g' -e 's|@PXESERVER_IP@|$(PXESERVER_IP)|g' -e 's|@PROJ_RELEASE_LONGNAME@|$(PROJ_RELEASE_LONGNAME)|g' $(HEX_DATADIR)/hex_install/hex_pxe_fetch.sh.in > $(ROOTDIR)/usr/sbin/hex_pxe_fetch
+	$(Q)chmod 755 $(ROOTDIR)/usr/sbin/hex_pxe_fetch
+	$(Q)echo "/usr/sbin/hex_pxe_fetch" >> $(ROOTDIR)/etc/rc.d/rc.local
 	$(Q)chroot $(ROOTDIR) bash -c "chmod 755 /etc/rc.d/rc.local"
-	$(Q)echo "fi" >> $(ROOTDIR)/etc/rc.d/rc.local
 
 # Install project build label into installer image
 pxe_ramdisk_install:: build_label_install

--- a/scripts/makepxedeploy
+++ b/scripts/makepxedeploy
@@ -95,25 +95,28 @@ if [ -n "$PXE_NET_BUSID" ] ; then
     cat >>$TEMPDIR/pxelinux.cfg/default <<EOF
 label $NAME
 KERNEL /$NAME/$KERNEL
-APPEND initrd=/$NAME/$INITRD rw root=/dev/ram0 ramdisk_size=$RAMDISK_SIZE net.ifnames=0 console=tty0 console=ttyS0 $QUIET_KERNEL_ARG erst_disable pxe_net_busid=$PXE_NET_BUSID pxe_via_nfs=${SERVER}:${SRVDIR}/${NAME}
+APPEND initrd=/$NAME/$INITRD rw root=/dev/ram0 ramdisk_size=$RAMDISK_SIZE net.ifnames=0 console=tty0 console=ttyS0 $QUIET_KERNEL_ARG erst_disable ${PXE_EXTRA_KERNEL_ARGS:-} pxe_net_busid=$PXE_NET_BUSID pxe_via_nfs=${SERVER}:${SRVDIR}/${NAME}
 EOF
 else
     cat >>$TEMPDIR/pxelinux.cfg/default <<EOF
 label $NAME
 KERNEL /$NAME/$KERNEL
-APPEND initrd=/$NAME/$INITRD rw root=/dev/ram0 ramdisk_size=$RAMDISK_SIZE net.ifnames=0 console=tty0 console=ttyS0 $QUIET_KERNEL_ARG erst_disable pxe_via_nfs=${SERVER}:${SRVDIR}/${NAME}
+APPEND initrd=/$NAME/$INITRD rw root=/dev/ram0 ramdisk_size=$RAMDISK_SIZE net.ifnames=0 console=tty0 console=ttyS0 $QUIET_KERNEL_ARG erst_disable ${PXE_EXTRA_KERNEL_ARGS:-} pxe_via_nfs=${SERVER}:${SRVDIR}/${NAME}
 EOF
 fi
 
 # UEFI configurations
+# The entry is deleted + regenerated on every deploy, so custom kernel args set
+# by editing grub.cfg would be lost. PXE_EXTRA_KERNEL_ARGS (profile or env,
+# e.g. "autoinstall driver_server=<url>") survives redeploys instead.
 sed -i "/linuxefi \/$NAME\//d" $TEMPDIR/grub.cfg
 if [ -n "$PXE_NET_BUSID" ] ; then
     cat >>$TEMPDIR/grub.cfg <<EOF
-menuentry  '$NAME (UEFI)' { linuxefi /$NAME/$KERNEL rw root=/dev/ram0 ramdisk_size=$RAMDISK_SIZE net.ifnames=0 init= console=tty0 console=ttyS0 $QUIET_KERNEL_ARG erst_disable pxe_net_busid=$PXE_NET_BUSID pxe_via_nfs=${SERVER}:${SRVDIR}/${NAME} ; initrdefi /$NAME/$INITRD}
+menuentry  '$NAME (UEFI)' { linuxefi /$NAME/$KERNEL rw root=/dev/ram0 ramdisk_size=$RAMDISK_SIZE net.ifnames=0 init= console=tty0 console=ttyS0 $QUIET_KERNEL_ARG erst_disable ${PXE_EXTRA_KERNEL_ARGS:-} pxe_net_busid=$PXE_NET_BUSID pxe_via_nfs=${SERVER}:${SRVDIR}/${NAME} ; initrdefi /$NAME/$INITRD}
 EOF
 else
     cat >>$TEMPDIR/grub.cfg <<EOF
-menuentry  '$NAME (UEFI)' { linuxefi /$NAME/$KERNEL rw root=/dev/ram0 ramdisk_size=$RAMDISK_SIZE net.ifnames=0 init= console=tty0 console=ttyS0 $QUIET_KERNEL_ARG erst_disable pxe_via_nfs=${SERVER}:${SRVDIR}/${NAME} ; initrdefi /$NAME/$INITRD }
+menuentry  '$NAME (UEFI)' { linuxefi /$NAME/$KERNEL rw root=/dev/ram0 ramdisk_size=$RAMDISK_SIZE net.ifnames=0 init= console=tty0 console=ttyS0 $QUIET_KERNEL_ARG erst_disable ${PXE_EXTRA_KERNEL_ARGS:-} pxe_via_nfs=${SERVER}:${SRVDIR}/${NAME} ; initrdefi /$NAME/$INITRD }
 EOF
 fi
 

--- a/src/hex_config/config_main.cpp
+++ b/src/hex_config/config_main.cpp
@@ -2842,16 +2842,9 @@ MainApplySnapshot(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    // Remove the existing system files that will be replaced by the snapshot
-    SnapshotFileRemove(backupFiles);
-
-    // Apply the files from the snapshot
-    if (!SnapshotFileInstall("/", tmpDir, managedFiles)) {
-        HexLogError("Could not restore snapshot files.");
-        if (!SnapshotFileRevert(managedFiles, backupDir, backupFiles))
-            HexLogError("Could not revert to previous system state.");
-        return EXIT_FAILURE;
-    }
+    // Managed state-marker files are installed after a successful commit (see
+    // below) so the module commits observe the node's real state — a fresh
+    // reimage runs first-time setup instead of skipping it.
 
     SnapshotCommandList& snapshotCmds = s_staticsPtr->snapshotCommands;
 
@@ -2899,13 +2892,21 @@ MainApplySnapshot(int argc, char** argv)
         // HexLogEventNoArg("Reverting snapshot changes.");
         HexLogDebugN(FWD, "Reverting snapshot changes.");
 
-        SnapshotFileRevert(managedFiles, backupDir, backupFiles);
+        // Managed files were not installed yet — only roll back module config.
         for (SnapshotCommandList::const_iterator iter = snapshotCmds.begin();
              iter != snapshotCmds.end(); ++iter) {
             if (iter->rollback != NULL && (iter->rollback(backupDir) & EXIT_FAILURE) != 0) {
                 // HexLogEventNoArg("Error performing rollback for %s component.", iter->name.c_str());
                 HexLogError("Error performing rollback for %s component.", iter->name.c_str());
             }
+        }
+    }
+    else {
+        // Commit succeeded — stamp the snapshot's managed state markers now.
+        SnapshotFileRemove(backupFiles);
+        if (!SnapshotFileInstall("/", tmpDir, managedFiles)) {
+            HexLogError("Could not install snapshot managed files.");
+            status = EXIT_FAILURE;
         }
     }
 

--- a/src/hex_pxe_rd/Makefile
+++ b/src/hex_pxe_rd/Makefile
@@ -17,7 +17,7 @@ PROJ_BASE_ROOTFS = $(HEX_INSTALL_RD)
 # Install directly to final ramdisk image
 PROJ_ROOTFS = $(HEX_PXE_RD)
 
-PXE_RD_PKGS := net-tools iproute wget curl dhcp-client vim-enhanced tftp nfs-utils rsync
+PXE_RD_PKGS := net-tools iproute iputils util-linux wget curl dhcp-client vim-enhanced tftp nfs-utils rsync openssh-server tcpdump ethtool
 
 $(call PROJ_INSTALL_DNF,,$(PXE_RD_PKGS))
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Installer half of the zero-touch feature (server/SPA ships from `cube-cos-driver`):

- `hex_autoinstall.sh.in` — on `driver_server=`, run `phone-home-agent --preflight` before restore (validate fabric, block until green-light-1); use the appointed OS disk, stage the pre-fetched snapshot into the rootfs, report restore-complete, log to VGA+serial; auto-install `/etc/issue` banner set at runtime, only when armed. OS-disk auto-detect skips SAN LUNs by transport (`HEX_INSTALL_SKIP_TRANSPORTS ?= fc iscsi fcoe`) + project data-label prefix (`HEX_INSTALL_DATA_LABEL_PREFIX`, cubecos: `cube_`).
- `hex_pxe_fetch.sh.in` — the installer's rc.local tail as a reviewable standalone script: image fetch (HTTP/NFS, wait-for-network + retry, 7200s bound + `rsync --append` resume), optional pre-fetch/inspect hook, zero-touch-gated diagnostics (sshd root/admin + spare-VT shells, `--no-block` to avoid a boot-transaction deadlock).
- `makepxedeploy` — `PXE_EXTRA_KERNEL_ARGS` (profile/env) baked into regenerated PXE entries, so deploy args like `autoinstall driver_server=<url>` survive redeploys instead of being stripped.
- `hex_pxe_rd` — add iputils, util-linux, openssh-server, tcpdump, ethtool.
- `config_main.cpp` — install snapshot managed-markers only after a successful commit, so reimaged nodes run FTS (fixes the control VIP never coming up).
- Consumer paths are project vars with hex defaults: `HEX_AGENT_ENV_DIR ?= /etc/appliance` (cubecos: `/etc/cube`).

#### Which issue(s) this PR fixes

Part of bigstack-oss/cubecos#1177

#### Special notes for your reviewer

- Paired with cubecos #1178 (bumps this submodule) — merge this first.
- Field-validated 2026-07-28: full zero-touch 1cc + 3cc HA reimage to `cluster check` all-ok; the marker fix brought the HA master VIP up; the `--no-block` deadlock and fetch-timeout fixes were hit and verified live.

#### Additional documentation

```docs
Zero-touch PXE preflight; snapshot managed markers install after a successful
commit so reimaged nodes run first-time setup. PXE_EXTRA_KERNEL_ARGS persists
deploy-specific kernel args across pxedeploys.
```
