### PR TITLE
docs(pxe): makepxedeploy emits clean entries; driver arms at deploy time

### DIFF
--- a/data/hex_install/hex_autoinstall.sh.in
+++ b/data/hex_install/hex_autoinstall.sh.in
@@ -146,6 +146,15 @@ if [ -n "$driver_server" ]; then
                         say "staged snapshot into rootfs for local apply ($(stat -c%s /run/appointed.snapshot 2>/dev/null) bytes)"
                     fi
                 fi
+                # Stage the operator's set_ready params too (pre-fetched before
+                # preflight, like the snapshot): the OS agent reads them locally
+                # and runs cluster set_ready with no network to the driver.
+                if [ -f /run/set-ready.json ]; then
+                    mkdir -p "$mnt/var/support"
+                    if cp -f /run/set-ready.json "$mnt/var/support/set-ready.json"; then
+                        say "staged set_ready params into rootfs for offline set_ready"
+                    fi
+                fi
                 umount "$mnt"
                 break
             fi

--- a/data/hex_install/hex_autoinstall.sh.in
+++ b/data/hex_install/hex_autoinstall.sh.in
@@ -119,23 +119,16 @@ if [ -n "$driver_server" ]; then
             if [ -d "$mnt/etc/appliance" ]; then
                 mkdir -p "$mnt@HEX_AGENT_ENV_DIR@"
                 echo "DRIVER_SERVER=$driver_server" > "$mnt@HEX_AGENT_ENV_DIR@/phone-home-agent.env"
-                # Hot-update the installed OS-phase agent from the driver, so an
-                # agent fix ships without a full image rebuild. Best-effort,
-                # checksum-verified; on any failure the baked-in agent stays.
-                # Targets this restored root (the one that boots) — same as the
-                # env file above — so the A/B layout needs no special handling.
-                new="$mnt/usr/sbin/phone-home-agent.new"
-                if wget -q -T 60 -O "$new" "$driver_server/api/v1/agents/binary" 2>/dev/null && [ -s "$new" ]; then
-                    want=$(wget -q -T 10 -O - "$driver_server/api/v1/agents/binary.sha256" 2>/dev/null | awk '{print $1}')
-                    got=$(sha256sum "$new" 2>/dev/null | awk '{print $1}')
-                    if [ -n "$want" ] && [ "$want" = "$got" ]; then
-                        chmod 0755 "$new" && mv -f "$new" "$mnt/usr/sbin/phone-home-agent"
-                        say "hot-updated installed agent from driver (${got:0:12})"
-                    else
-                        rm -f "$new"; say "agent hot-update checksum mismatch; keeping baked-in agent"
-                    fi
-                else
-                    rm -f "$new" 2>/dev/null; say "no driver-packed agent (or fetch failed); keeping baked-in agent"
+                # Install the hot-fetched agent into the restored rootfs (OS
+                # phase). It was already fetched from the driver BEFORE preflight
+                # (hex_pxe_fetch), over the pre-preflight connection — so this is
+                # a local copy, no network needed here (preflight may have torn
+                # down the route to the driver). Only replaces the baked-in agent
+                # when a fresh one was actually fetched; targets this restored
+                # root (same as the env file), so A/B needs no special handling.
+                if [ -s /run/phone-home-agent.fresh ]; then
+                    install -m 0755 /run/phone-home-agent.fresh "$mnt/usr/sbin/phone-home-agent" \
+                        && say "installed hot-fetched agent into rootfs (OS phase)"
                 fi
                 # Carry over any identity the preflight agent stamped for the
                 # installed agent to reuse.

--- a/data/hex_install/hex_autoinstall.sh.in
+++ b/data/hex_install/hex_autoinstall.sh.in
@@ -126,8 +126,10 @@ if [ -n "$driver_server" ]; then
                 # down the route to the driver). Only replaces the baked-in agent
                 # when a fresh one was actually fetched; targets this restored
                 # root (same as the env file), so A/B needs no special handling.
-                if [ -s /run/phone-home-agent.fresh ]; then
-                    install -m 0755 /run/phone-home-agent.fresh "$mnt/usr/sbin/phone-home-agent" \
+                # NOTE: the OS image installs the agent to /usr/local/bin (see
+                # the systemd unit ExecStart) — NOT /usr/sbin like the installer.
+                if [ -s /run/phone-home-agent.fresh ] && [ -d "$mnt/usr/local/bin" ]; then
+                    install -m 0755 /run/phone-home-agent.fresh "$mnt/usr/local/bin/phone-home-agent" \
                         && say "installed hot-fetched agent into rootfs (OS phase)"
                 fi
                 # Carry over any identity the preflight agent stamped for the

--- a/data/hex_install/hex_autoinstall.sh.in
+++ b/data/hex_install/hex_autoinstall.sh.in
@@ -119,6 +119,24 @@ if [ -n "$driver_server" ]; then
             if [ -d "$mnt/etc/appliance" ]; then
                 mkdir -p "$mnt@HEX_AGENT_ENV_DIR@"
                 echo "DRIVER_SERVER=$driver_server" > "$mnt@HEX_AGENT_ENV_DIR@/phone-home-agent.env"
+                # Hot-update the installed OS-phase agent from the driver, so an
+                # agent fix ships without a full image rebuild. Best-effort,
+                # checksum-verified; on any failure the baked-in agent stays.
+                # Targets this restored root (the one that boots) — same as the
+                # env file above — so the A/B layout needs no special handling.
+                new="$mnt/usr/sbin/phone-home-agent.new"
+                if wget -q -T 60 -O "$new" "$driver_server/api/v1/agents/binary" 2>/dev/null && [ -s "$new" ]; then
+                    want=$(wget -q -T 10 -O - "$driver_server/api/v1/agents/binary.sha256" 2>/dev/null | awk '{print $1}')
+                    got=$(sha256sum "$new" 2>/dev/null | awk '{print $1}')
+                    if [ -n "$want" ] && [ "$want" = "$got" ]; then
+                        chmod 0755 "$new" && mv -f "$new" "$mnt/usr/sbin/phone-home-agent"
+                        say "hot-updated installed agent from driver (${got:0:12})"
+                    else
+                        rm -f "$new"; say "agent hot-update checksum mismatch; keeping baked-in agent"
+                    fi
+                else
+                    rm -f "$new" 2>/dev/null; say "no driver-packed agent (or fetch failed); keeping baked-in agent"
+                fi
                 # Carry over any identity the preflight agent stamped for the
                 # installed agent to reuse.
                 if [ -f /run/phone-home-agent.env ]; then

--- a/data/hex_install/hex_pxe_fetch.sh.in
+++ b/data/hex_install/hex_pxe_fetch.sh.in
@@ -68,6 +68,36 @@ else
     timeout 10 umount /mnt/nfs || umount -l /mnt/nfs
 fi
 
+# Hot-update the phone-home-agent from the driver NOW — before preflight, over
+# the same connection that just fetched the .pkg. Preflight reconfigures the
+# network (bond/vlan/static IP) and may tear down the route to the driver, so we
+# can't rely on fetching later. The fresh agent is used for preflight and
+# restore-done immediately (installed over the installer's own), and stashed at
+# /run/phone-home-agent.fresh for hex_autoinstall to copy into the restored
+# rootfs (OS phase). Best-effort + checksum-verified; on any failure the
+# baked-in agent stays.
+if grep -q 'driver_server=' /proc/cmdline && [ -x /usr/sbin/phone-home-agent ]; then
+    ds=""
+    for i in $(cat /proc/cmdline); do case "$i" in driver_server=*) ds="${i#driver_server=}" ;; esac; done
+    if [ -n "$ds" ]; then
+        f=/run/phone-home-agent.fresh
+        if wget -q -T 60 -O "$f" "$ds/api/v1/agents/binary" 2>/dev/null && [ -s "$f" ]; then
+            want=$(wget -q -T 10 -O - "$ds/api/v1/agents/binary.sha256" 2>/dev/null | awk '{print $1}')
+            got=$(sha256sum "$f" 2>/dev/null | awk '{print $1}')
+            if [ -n "$want" ] && [ "$want" = "$got" ]; then
+                chmod 0755 "$f" && cp -f "$f" /usr/sbin/phone-home-agent
+                echo "[rc.local] hot-updated phone-home-agent from driver (${got:0:12})" | tee /dev/tty0 /dev/console >/dev/null 2>&1
+            else
+                rm -f "$f"
+                echo "[rc.local] agent hot-update checksum mismatch; keeping baked-in agent" | tee /dev/tty0 /dev/console >/dev/null 2>&1
+            fi
+        else
+            rm -f "$f" 2>/dev/null
+            echo "[rc.local] no driver-packed agent (or fetch failed); keeping baked-in agent" | tee /dev/tty0 /dev/console >/dev/null 2>&1
+        fi
+    fi
+fi
+
 # After the image is fetched, unattended-install if the kernel cmdline carries
 # `autoinstall` (inert otherwise).
 /usr/sbin/hex_autoinstall

--- a/scripts/makepxedeploy
+++ b/scripts/makepxedeploy
@@ -106,9 +106,11 @@ EOF
 fi
 
 # UEFI configurations
-# The entry is deleted + regenerated on every deploy, so custom kernel args set
-# by editing grub.cfg would be lost. PXE_EXTRA_KERNEL_ARGS (profile or env,
-# e.g. "autoinstall driver_server=<url>") survives redeploys instead.
+# Entries are deleted + regenerated on every deploy — always CLEAN (no arming
+# args baked in). The zero-touch driver injects "autoinstall driver_server=<url>"
+# into the selected entry when a deploy starts and strips it after the nodes
+# boot, so arming is transient and driver-owned and can't go stale across
+# redeploys. PXE_EXTRA_KERNEL_ARGS still works as a manual/profile override.
 sed -i "/linuxefi \/$NAME\//d" $TEMPDIR/grub.cfg
 if [ -n "$PXE_NET_BUSID" ] ; then
     cat >>$TEMPDIR/grub.cfg <<EOF


### PR DESCRIPTION
Reworked from the earlier carry-forward approach (per design discussion). `makepxedeploy` regenerates PXE entries **clean** (no arming baked in); the zero-touch driver injects/strips `autoinstall driver_server=<url>` on the selected entry per deploy (cube-cos-driver #<driver-arms PR>). This just documents the contract so build-time arming isn't re-added. `PXE_EXTRA_KERNEL_ARGS` remains for manual/profile overrides.

Fixes #146 (reworded: 'makepxedeploy should emit clean, driver-armable entries').