### PR TITLE
fix(console): stop status/agent lines staircasing across install + boot

### DIFF
--- a/data/hex_config/bootstrap_hex_config
+++ b/data/hex_config/bootstrap_hex_config
@@ -3,5 +3,5 @@ if [ -f /etc/bootstrap.cfg ]; then
     . /etc/bootstrap.cfg
 fi
 /usr/sbin/hex_config bootstrap $BOOTSTRAP_MODULE || true
-printf "\nBootstrap Done" | tee -a $(/usr/sbin/hex_sdk GetKernelConsoleDevices) >/dev/null 2>&1 || true
+printf "\nBootstrap Done\n" | tee -a $(/usr/sbin/hex_sdk GetKernelConsoleDevices) >/dev/null 2>&1 || true
 touch /run/bootstrap_done

--- a/data/hex_install/hex_autoinstall.sh.in
+++ b/data/hex_install/hex_autoinstall.sh.in
@@ -11,6 +11,11 @@
 #
 set -e
 
+# Install consoles can boot in raw mode (no \n->\r\n mapping), which staircases
+# tee'd status lines (new line, no return to column 0). Enable onlcr on the VGA +
+# serial consoles so plain echo/tee output prints cleanly.
+for _t in /dev/tty0 /dev/ttyS0 /dev/console ; do stty -F "$_t" onlcr 2>/dev/null || true ; done
+
 # Mirror progress to the VGA (/dev/tty0 — the BMC KVM) and serial consoles.
 # /dev/tty0 is required: userspace writes to /dev/console only reach the last
 # console= (serial), never the VGA screen.
@@ -79,7 +84,16 @@ if [ -n "$driver_server" ] && [ -x /usr/sbin/phone-home-agent ]; then
     /usr/sbin/modprobe ipmi_devintf 2>/dev/null || true
     say "network preflight: nic bringup + bond/vlan/ip + carrier + peer ping (waits for green light 1) ..."
     SECONDS=0
-    if ! /usr/sbin/phone-home-agent --preflight --server "$driver_server"; then
+    # Route the agent's log through the (onlcr) consoles so its lines print
+    # cleanly instead of staircasing like the say() status lines did. Disable
+    # errexit around the pipe and read PIPESTATUS[0] so tee's status doesn't mask
+    # the agent's real exit.
+    set +e
+    /usr/sbin/phone-home-agent --preflight --server "$driver_server" 2>&1 \
+        | tee -a $(/usr/sbin/hex_sdk GetKernelConsoleDevices) >/dev/null
+    _pf_rc=${PIPESTATUS[0]}
+    set -e
+    if [ "$_pf_rc" != 0 ]; then
         say "PREFLIGHT FAILED (${SECONDS}s); leaving installer at prompt for inspection"
         exit 1
     fi

--- a/data/hex_install/hex_pxe_fetch.sh.in
+++ b/data/hex_install/hex_pxe_fetch.sh.in
@@ -6,6 +6,10 @@
 
 for i in $(cat /proc/cmdline); do if [[ $i =~ pxe_via_nfs= ]]; then eval $i ; fi ; done
 
+# Install consoles can boot in raw mode (no \n->\r\n), staircasing status lines;
+# enable onlcr on the VGA + serial consoles so tee'd output prints cleanly.
+for _t in /dev/tty0 /dev/ttyS0 /dev/console ; do stty -F "$_t" onlcr 2>/dev/null || true ; done
+
 # Zero-touch diagnostics: on an unattended boot (autoinstall / driver_server=),
 # bring up sshd (root/admin) + spare-VT login shells so an operator can
 # investigate a headless install — remotely or via Alt-F2/F3 — while it runs on

--- a/data/os/init_functions.sh
+++ b/data/os/init_functions.sh
@@ -34,6 +34,12 @@ GetKernelConsoleDevices()
     local devices=
     for C in $(GetKernelConsoles) ; do
         devices="$devices /dev/$C"
+        # Install/boot consoles can come up in raw mode (-onlcr), which staircases
+        # \n-terminated status lines. Enable onlcr so every writer to these devices
+        # (bootstrap, hwdetect, support, proj_functions, ...) prints cleanly.
+        # Best-effort + silent: must not touch this function's stdout, which is the
+        # device list consumed via $(GetKernelConsoleDevices).
+        stty -F "/dev/$C" onlcr >/dev/null 2>&1 || true
     done
     echo $devices
 }


### PR DESCRIPTION
## Problem

Install/boot consoles come up in **raw mode (`-onlcr`)**, so `\n`-terminated status lines don't return to column 0 — they **staircase** on the BMC KVM. Affects the installer status lines, the `phone-home-agent --preflight` log, and the OS/boot writers (`Bootstrap Done`, hwdetect, …).

## Fix

- **Installer consoles**: enable `onlcr` early in `hex_pxe_fetch` + `hex_autoinstall`.
- **One central fix for every OS/boot writer**: `GetKernelConsoleDevices()` now enables `onlcr` on each console device it returns — so everything that tees to it prints cleanly: `bootstrap_hex_config` ("Bootstrap Done"), `rc.hwdetect.sh`, `sdk_support`, `proj_functions`, `bootstrap_cube_config`, and the pxeserver `rc.sysinit` lines.
- **Agent log**: route `phone-home-agent --preflight` output through the (onlcr) consoles, `PIPESTATUS[0]`-correct under `set -e` so `tee`'s status can't mask a preflight failure.
- `Bootstrap Done` gets a trailing newline.

## Verified

Live on the R630 1cc console (BMC KVM): with `-onlcr`, agent/status lines staircase; with `onlcr`, the same lines print clean at column 0.

## Definition of Done
- [x] **Handbook** — documented in `kb/cube-cos-driver/known-issues/known-issues-and-limitations.md` (item 6, console staircase → fixed here) and `kb/cube-cos-driver/architecture/pxeserver-integration.md` (onlcr in the installer chain); merged in bigstack-handbook #196.

Fixes #149.
