### PR TITLE
docs(github): require a QA Verification section in the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,3 +38,26 @@ Add any other context about the problem here.
 
 - Hardware [e.g. CPU, RAM, Disk Controller, Disks]
 - Supporting logs
+
+## QA Verification
+
+> How QA verifies this issue is actually fixed — write **checkable claims**: the exact
+> command or click path plus the expected outcome. "Verify it works" is not a checkable
+> claim. These claims are what the Qase test suite is generated from, so write them for a
+> reader who has not seen the code.
+
+| # | Command / steps | Expected outcome |
+|---|---|---|
+| 1 | `...` | `...` |
+
+- [ ] **QA Status declared at Done** — when this issue reaches `Done`, set the board's
+      `QA Status` field to `Not needed` or `Ready to QA`. Never leave it empty on a Done
+      ticket; `In QA` / `Verified` are QA's own transitions.
+
+## Output artifacts (Definition of Done)
+
+> Beyond code, docs, and config changes, completing this issue must also deliver:
+
+- [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
+      work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
+      `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,3 +18,26 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+
+## QA Verification
+
+> How QA verifies this capability once it ships — write **checkable claims**: the exact
+> command or click path plus the expected outcome. "Verify it works" is not a checkable
+> claim. These claims are what the Qase test suite is generated from, so write them for a
+> reader who has not seen the code.
+
+| # | Command / steps | Expected outcome |
+|---|---|---|
+| 1 | `...` | `...` |
+
+- [ ] **QA Status declared at Done** — when this issue reaches `Done`, set the board's
+      `QA Status` field to `Not needed` or `Ready to QA`. Never leave it empty on a Done
+      ticket; `In QA` / `Verified` are QA's own transitions.
+
+## Output artifacts (Definition of Done)
+
+> Beyond code, docs, and config changes, completing this issue must also deliver:
+
+- [ ] **Handbook knowledge update** — land the durable, team-readable knowledge from this
+      work into the bigstack-handbook cubecos kb (`kb/cubecos/…`) via
+      `/bigstack-core:save-to-handbook` (Topic / Runbook / Known-issue / ADR as fits).

--- a/.github/workflows/fast-forward-merge.yaml
+++ b/.github/workflows/fast-forward-merge.yaml
@@ -5,20 +5,33 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   merge:
+    permissions:
+      contents: write  # for Git to git push
     if: ${{ github.event.label.name == 'done' && github.event.pull_request.mergeable == true }}
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@df199fb7be9f65074067a9eb93f12bb4c5547cf2 # v2.13.3
+        with:
+          egress-policy: audit
+
       - name: Check Out PR Target Branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 0 # fetches all history for all branches and tags
       - name: Merge
         env: 
           TOPIC_BRANCH: ${{ github.head_ref }}
+          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
-          git pull origin $TOPIC_BRANCH
-          git checkout $TOPIC_BRANCH
-          git checkout @{-1}
+          git fetch origin $TOPIC_BRANCH
+          git checkout $BASE_BRANCH
           git branch
-          git merge --ff-only $TOPIC_BRANCH
-          git push
+          git merge --ff-only origin/$TOPIC_BRANCH
+          git push origin $BASE_BRANCH

--- a/.github/workflows/fast-forward-merge.yaml
+++ b/.github/workflows/fast-forward-merge.yaml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: read
 
+# Serialize per target branch: two PRs labeled at once would race, and the loser's
+# push is rejected as non-fast-forward with no retry. Never cancel-in-progress —
+# a cancelled run can leave the label set on an unmerged PR.
+concurrency:
+  group: fast-forward-merge-${{ github.event.pull_request.base.ref }}
+  cancel-in-progress: false
+
 jobs:
   merge:
     permissions:
@@ -30,8 +37,7 @@ jobs:
           TOPIC_BRANCH: ${{ github.head_ref }}
           BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
         run: |
-          git fetch origin $TOPIC_BRANCH
-          git checkout $BASE_BRANCH
-          git branch
-          git merge --ff-only origin/$TOPIC_BRANCH
-          git push origin $BASE_BRANCH
+          git fetch origin "$TOPIC_BRANCH"
+          git checkout "$BASE_BRANCH"
+          git merge --ff-only "origin/$TOPIC_BRANCH"
+          git push origin "$BASE_BRANCH"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -42,6 +42,6 @@ jobs:
           retention-days: 5
 
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3.29.5
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation
/kind bug

#### What this PR does / why we need it

Three `.github/` changes for hex, one commit each.

**1. `docs(github)` — bake the handbook's QA-verification requirement into the issue templates**

`bug_report.md` and `feature_request.md` gain a `## QA Verification` section, and the
handbook-knowledge DoD block they were missing is backfilled. Two handbook requirements are
encoded:

- [`claude-code-development-flow.md`](https://github.com/bigstack-oss/bigstack-handbook/blob/develop/kb/bigstack/workflows/claude-code-development-flow.md) —
  the Qase test suite is *generated from* the issue's verification claims, so they have to be
  **checkable claims** (command / click path + expected outcome), not prose. The new section
  gives that a fixed shape via a steps/outcome table.
- [`scrum-board-ticket-standard.md`](https://github.com/bigstack-oss/bigstack-handbook/blob/develop/kb/bigstack/workflows/scrum-board-ticket-standard.md) —
  `QA Status` is declared by the dev when the ticket reaches `Done` (`Not needed` /
  `Ready to QA`). The retired `needs-qa` label left no reminder anywhere, so it becomes a DoD
  checkbox.

The `## Output artifacts (Definition of Done)` handbook-knowledge block is already in cubecos
and cubecmp templates but was never added to hex, so an issue filed from hex silently skipped
the kb update. Backfilled here.

Scope: `bug_report.md` + `feature_request.md` only. `QA Status` exists solely on
Bug / Feature / User Story ticket types, so `custom.md` is intentionally untouched.

**2. `ci(merge)` — cherry-pick the fixed fast-forward-merge workflow from `openstack-develop`**

Cherry-pick of e5f87fe, already on `openstack-develop`, so `develop` carries the same
workflow and the eventual rebase of `openstack-develop` onto `develop` has nothing to resolve
here. It also fixes two real defects in the `develop` copy:

- `git pull origin $TOPIC_BRANCH` merged the topic branch *before* the explicit `--ff-only`
  check ran, so a non-fast-forwardable branch could be pushed as a **merge commit** — the
  opposite of what this workflow exists to guarantee.
- Without `fetch-depth: 0` the shallow clone can defeat the fast-forward check.

Plus least-privilege `permissions:` (read at workflow level, `contents: write` only on the
job) and a `harden-runner` audit step. Addressing the base branch explicitly is what makes
merges toward non-default branches work.

**3. `ci(scorecard)` — correct a stale action-version comment**

The dependabot bump in 44b2acb moved the `codeql-action/upload-sarif` pin from `e4fba868`
to `f205ea1c` but left the trailing `# v3.29.5` comment untouched. `f205ea1c` is actually
**v4.37.4** (the tag named v3.29.5 is `51f77329`), so the comment has been describing the
wrong release ever since — and reads as *older* than it is, which invites a pointless
"bump" back onto a genuinely older SHA. Comment only; the pinned SHA is unchanged.

#### Which issue(s) this PR fixes

None — process/CI change, no ticket.

#### Special notes for your reviewer

> - Both template sections are copy-identical to the ones in the paired cubecos PR, so the
>   two repos stay in sync. `feature_request.md` uses bold pseudo-headings; the new sections
>   use real `##` headings deliberately, so the shared boilerplate reads identically in every
>   repo.
> - One conflict was resolved in the cherry-pick: the `actions/checkout` pin stays at
>   develop's newer `3d3c42e5` (v7.0.1) rather than openstack-develop's `9c091bb2` (v7.0.0).
> - `harden-runner` lands at openstack-develop's `v2.13.3` pin as-is rather than v2.20.0, to
>   keep the cherry-pick faithful; hex's dependabot will bump it on its next weekly run.
> - After the paired cubecos PR refreshes its own pins, the two repos'
>   `fast-forward-merge.yaml` are identical except for that harden-runner pin
>   (cubecos goes to v2.20.0), which dependabot converges here.

#### Additional documentation

```docs

```
