### PR TITLE
fix(config): register a tuning's spec when it is declared

### DIFF
--- a/include/hex/config_impl.h
+++ b/include/hex/config_impl.h
@@ -121,6 +121,9 @@ struct TuningSpecString {
 
 struct Tuning {
     Tuning(const char *name, bool publish, const char *description);
+    // ensureSpec forces this tuning's construct-on-first-use spec into existence
+    // at declaration time; see the ctor in config_main.cpp for why.
+    Tuning(const char *name, bool publish, const char *description, void (*ensureSpec)());
 };
 
 struct SupportFile {

--- a/include/hex/config_module.h
+++ b/include/hex/config_module.h
@@ -188,22 +188,22 @@ int ApplyTrigger(ArgVec argv);
 #define CONFIG_TUNING_BOOL(key, name, publish, description, def) \
     hex_config::TuningSpecBool& key() \
     { static hex_config::TuningSpecBool s(name, def); return s; } \
-    static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description)
+    static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description, [](){ (void)key(); })
 
 #define CONFIG_TUNING_INT(key, name, publish, description, def, min, max) \
     hex_config::TuningSpecInt& key() \
     { static hex_config::TuningSpecInt s(name, def, min, max); return s; } \
-    static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description)
+    static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description, [](){ (void)key(); })
 
 #define CONFIG_TUNING_UINT(key, name, publish, description, def, min, max) \
     hex_config::TuningSpecUInt& key() \
     { static hex_config::TuningSpecUInt s(name, def, min, max); return s; } \
-    static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description)
+    static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description, [](){ (void)key(); })
 
 #define CONFIG_TUNING_STR(key, name, publish, description, def, type, regex)	\
     hex_config::TuningSpecString& key() \
     { static hex_config::TuningSpecString s(name, def, type, regex); return s; } \
-    static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description)
+    static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description, [](){ (void)key(); })
 
 /**
  *  @hideinitializer

--- a/src/hex_config/config_main.cpp
+++ b/src/hex_config/config_main.cpp
@@ -713,6 +713,36 @@ Tuning::Tuning(const char *name, bool publish, const char *description)
     s_staticsPtr->tuningList.push_back(info);
 }
 
+// Same, but also materialises the tuning's spec.
+//
+// Specs became construct-on-first-use to break a cross-translation-unit static
+// initialisation cycle: two modules parsing each other's specs could not both be
+// satisfied by any link order. That is still the right shape -- but it silently
+// changed an invariant. A spec used to be a namespace-scope object, so *declaring*
+// a tuning registered it; now only a PARSE_TUNING_*/CONFIG_TUNING_SPEC_* consumer
+// calling the accessor does. A tuning nobody parses therefore had no entry in
+// tuningSpecMap at all, and MainValidateTuningValue() reports exactly that case as
+// type "mix" and returns failure -- so `hex_config validate_tuning_value` failed on
+// a perfectly well-formed published tuning (keystone.debug.enabled, glance.debug.enabled).
+//
+// Calling the accessor here restores the old invariant without reintroducing the
+// cycle: the accessor is defined in the *same* translation unit as this Tuning
+// object, so this is an ordinary call that constructs the local static on demand,
+// not a load-time read of another TU's object. Cross-TU references stay lazy.
+Tuning::Tuning(const char *name, bool publish, const char *description, void (*ensureSpec)())
+{
+    StaticsInit();
+
+    if (ensureSpec)
+        ensureSpec();
+
+    TuningInfo info;
+    info.name = name;
+    info.publish = publish;
+    info.description = description;
+    s_staticsPtr->tuningList.push_back(info);
+}
+
 SupportFile::SupportFile(const char *pattern)
 {
     StaticsInit();

--- a/src/hex_config/tests/test_tuning_spec_01.cpp
+++ b/src/hex_config/tests/test_tuning_spec_01.cpp
@@ -1,0 +1,35 @@
+
+#include <hex/log.h>
+#include <hex/test.h>
+#include <hex/config_module.h>
+#include <hex/config_tuning.h>
+
+// Tunings that no module ever PARSE_es.
+//
+// Specs are construct-on-first-use (see test_tuning_cycle_01, which needs that
+// to break a cross-TU spec cycle). Only a PARSE_TUNING_*/CONFIG_TUNING_SPEC_*
+// consumer calls the accessor, so a tuning nobody parses used to end up with no
+// entry in the spec map at all -- validate_tuning_value then reported it as type
+// "mix" and returned failure for a perfectly well-formed published tuning.
+//
+// Declaring a tuning must register its spec, whether or not anyone parses it.
+
+CONFIG_TUNING_BOOL(LONELY_BOOL, "lonely.bool", TUNING_PUB,
+                   "declared, never parsed", false);
+
+CONFIG_TUNING_INT(LONELY_INT, "lonely.int", TUNING_PUB,
+                  "declared, never parsed", 5, 0, 10);
+
+// Control: same shape, but parsed -- this worked before and must keep working.
+CONFIG_TUNING_BOOL(PARSED_BOOL, "parsed.bool", TUNING_PUB,
+                   "declared and parsed", false);
+PARSE_TUNING_BOOL(s_parsedBool, PARSED_BOOL);
+
+static bool
+CommitLonely(bool modified, int dryLevel)
+{
+    HexLogDebugN(FWD, "Commit lonely");
+    return true;
+}
+
+CONFIG_MODULE(lonely, NULL, NULL, NULL, NULL, CommitLonely);

--- a/src/hex_config/tests/test_tuning_spec_01.sh
+++ b/src/hex_config/tests/test_tuning_spec_01.sh
@@ -1,0 +1,29 @@
+
+# A tuning that no module parses must still resolve its type, so
+# validate_tuning_value can accept a good value and reject a bad one.
+#
+# Regression guard: when specs became construct-on-first-use, nothing constructed
+# the spec of an unparsed tuning, so every line below exited 1 and the type
+# printed as "mix". That reached the product as `hex_config validate_tuning_value
+# keystone.debug.enabled true` failing on a released build.
+
+# unparsed bool: both values valid, a non-bool rejected
+./$TEST validate_tuning_value lonely.bool true
+./$TEST validate_tuning_value lonely.bool false
+! ./$TEST validate_tuning_value lonely.bool neutral
+
+# unparsed int: range enforced from the declaration's min/max
+./$TEST validate_tuning_value lonely.int 5
+./$TEST validate_tuning_value lonely.int 0
+./$TEST validate_tuning_value lonely.int 10
+! ./$TEST validate_tuning_value lonely.int 11
+! ./$TEST validate_tuning_value lonely.int notanint
+
+# parsed control keeps working
+./$TEST validate_tuning_value parsed.bool true
+! ./$TEST validate_tuning_value parsed.bool neutral
+
+# an undeclared tuning is still a failure
+! ./$TEST validate_tuning_value no.such.tuning true
+
+rm -f test.*


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

> **No longer stacked — #154 has merged.** This branch (`jim.lin/fix/release-wrapup`) was stacked on **#154** (`jim.lin/feat/v3110-rebase`); that PR is now merged into `develop`, so the diff shown here is exactly this PR's single commit (`3ae16b2`) and it is ready to review on its own.
>
> **Merge order.** This one goes first: [bigstack-oss/cubecos#1274](https://github.com/bigstack-oss/cubecos/pull/1274) points its `hex` submodule at `3ae16b2`, so that pointer dangles until this lands.

Restores an invariant that [`6219439`](https://github.com/bigstack-oss/hex/commit/6219439) changed without meaning to: **declaring a tuning must register its spec.**

That commit made tuning specs construct-on-first-use, which was the right call — it broke a cross-translation-unit static initialisation cycle that no link order could satisfy, and `test_tuning_cycle_01` covers it. But it moved the spec from a namespace-scope object into a function-local static:

```cpp
#define CONFIG_TUNING_BOOL(key, name, publish, description, def) \
    hex_config::TuningSpecBool& key() \
    { static hex_config::TuningSpecBool s(name, def); return s; } \   // constructed on first *call*
    static hex_config::Tuning HEX_CAT(s_tuning_, __LINE__)(name, publish, description)
```

The `Tuning` object is file-scope, so the tuning still lands in `tuningList` at load time and still shows up in a dump. The spec is only constructed when something *calls* the accessor — and the only thing that does is a `PARSE_TUNING_*` / `CONFIG_TUNING_SPEC_*` consumer. **A tuning that no module parses therefore ends up with no entry in `tuningSpecMap` at all.**

`MainValidateTuningValue()` treats precisely that case as type `mix` and returns failure:

```cpp
bool result = 1;                          // starts as FAILURE
...
specIt = tsm.find(it->name);
if (specIt == tsm.end())
    printf("mix`na`na`na`na");            // no spec -> prints "mix", result stays 1
else {
    switch (specIt->second.type) {
    case TUNING_BOOL:
        if (HexValidateBool(value)) result = 0;   // the only path to success
```

so on a released build:

```
# hex_config validate_tuning_value keystone.debug.enabled true
# echo $?
1
```

for a perfectly well-formed published bool.

**How it surfaced.** `centos9_cubecos_accept` #706 failed two topologies on the same assertion — `test_60_cc1_tuning` (3cc) and `test_63_ec1_tuning` (2ec_1m), which are byte-identical files and both do exactly this call. `keystone.debug.enabled` and `glance.debug.enabled` are the only two tunings affected today; every other `<svc>.debug.enabled` is parsed by its own module and so kept its spec. The dump makes the split visible:

```
keystone.debug.enabled   ...  [mix|na|na|na|na]        <- no spec
glance.debug.enabled     ...  [mix|na|na|na|na]        <- no spec
neutron.debug.enabled    ...  [bool|False|false|true|na]
nova.debug.enabled       ...  [bool|False|false|true|na]
```

**The fix.** Give `Tuning` an overload taking a thunk, and have the four typed `CONFIG_TUNING_*` macros pass a captureless lambda that calls their own accessor. Construct-on-first-use is kept, so the cycle stays fixed — this is safe precisely because the accessor is defined in the *same* translation unit as the `Tuning` object, making it an ordinary call rather than a load-time read of another TU's object. Cross-TU references stay lazy.

#### Which issue(s) this PR fixes

Part of [#614](https://github.com/bigstack-oss/cubecos/issues/614) . Found by the failing accept pipeline rather than reported. Context and the consuming change live in [bigstack-oss/cubecos#1274](https://github.com/bigstack-oss/cubecos/pull/1274), which bumps this submodule.

#### Special notes for your reviewer

**Worth knowing this is latent, not new.** It reproduces on the *green* `accept-1ec` node too — 1ec passes only because the tuning test exists solely in the 3cc and 2ec_1m suites. So the exposure predates v3.1.10; the accept run is just where a suite finally asserted it.

**On the two affected tunings.** They are inert for a second, independent reason: both are declared `TUNING_PUB` but neither module ever parsed or applied them, so setting them did nothing. That is fixed separately on the cubecos side (`a2a01c4`). The two fixes are independent, and either alone unblocks the failing tests — verified by building against *pristine* hex with only the cubecos-side `PARSE_TUNING_BOOL` added, which is enough for `validate_tuning_value` to resolve both. Both are wanted: this one restores the general invariant so the next declared-but-unparsed tuning does not silently repeat it.

**Verification**

`test_tuning_spec_01` (added here) declares two tunings nobody parses plus a parsed control, and asserts `validate_tuning_value` accepts good values and rejects bad ones:

| | pristine hex | patched hex |
|---|---|---|
| `test_tuning_spec_01` | **fails** at the first assertion | **passes** |
| `test_tuning_cycle_01` | passes | **still passes** |

Built in the `centos9_cubecos_accept` container, full `core/modules` rebuild (91 objects) plus link, no new warnings:

```
keystone.debug.enabled true      exit=0 (was 1)
glance.debug.enabled true        exit=0 (was 1)
keystone.debug.enabled neutral   exit=1 (still correctly rejected)
nova.control.host.vcpu 129       exit=1 (still correctly rejected)
```

and the pristine binary rebuilt from the same tree reproduces the original `exit=1`, so the A/B is on one variable.

Also landed on a live node (`jim-1cc`, firmware `CUBE_3.1.10_20260816-2145_86f41d2`) as an install-form binary with setuid preserved, where the same three checks hold.

#### Additional documentation

```docs
None. The macro contract is unchanged for callers -- modules using
CONFIG_TUNING_* / CONFIG_TUNING_SPEC_* / PARSE_TUNING_* need no edits, exactly
as with 6219439.
```

